### PR TITLE
Clarify requirement for test_code

### DIFF
--- a/anatomy/track-tooling/test-runners/interface.md
+++ b/anatomy/track-tooling/test-runners/interface.md
@@ -65,6 +65,9 @@ This is the name of the test in a human-readable format.
 
 > key: `test_code`
 
+This **MUST** be present for Concept Exercises and **SHOULD** be present for Practice Exercises. 
+The difference in this requirement comes from that fact that students are not shown the tests in Concept Exercises, so solving the exercise may be impossible without the `text_code` being shown, whereas the tests are shown for Practice Exercises.
+
 This is the body of the command that is being tests. It should have any `skip` annotations removed. For example, the following Ruby test:
 
 ```ruby

--- a/anatomy/track-tooling/test-runners/interface.md
+++ b/anatomy/track-tooling/test-runners/interface.md
@@ -66,7 +66,7 @@ This is the name of the test in a human-readable format.
 > key: `test_code`
 
 This **MUST** be present for Concept Exercises and **SHOULD** be present for Practice Exercises. 
-The difference in this requirement comes from that fact that students are not shown the tests in Concept Exercises, so solving the exercise may be impossible without the `text_code` being shown, whereas the tests are shown for Practice Exercises.
+The difference in this requirement comes from that fact that students are not shown the tests in Concept Exercises, so solving the exercise may be impossible without the `test_code` being shown, whereas the tests are shown for Practice Exercises.
 
 This is the body of the command that is being tests. It should have any `skip` annotations removed. For example, the following Ruby test:
 


### PR DESCRIPTION
From the experiences of many tracks, adding the `test_code` field is achievable for new exercises but hard/impossible for some old exercises. This clarifies the requirement.