### PR TITLE
Specify that tests must be output in order

### DIFF
--- a/anatomy/track-tooling/test-runners/interface.md
+++ b/anatomy/track-tooling/test-runners/interface.md
@@ -62,7 +62,7 @@ This is an array of the test results, specified in the "Per-test" section below.
 The tests **MUST** be returned in the order they are specified in the tests file.
 For languages that execute tests in a random order, this may mean re-ordering the results in line with the order specified in the tests file.
 
-The rationale for this is that only the first failure is show to students and therefore it is important that the correct failure is shown. Because tests are generally ordered in that file in a TDD way, and because for Practice Exercises the students see the tests file in the editor, aligning the results with the file is critical.
+The rationale for this is that only the first failure is shown to students and therefore it is important that the correct failure is shown. Because tests are generally ordered in the tests file in a TDD way, and because for Practice Exercises the students see the tests file in the editor, aligning the results with the tests file is critical.
 
 ### Per-test
 

--- a/anatomy/track-tooling/test-runners/interface.md
+++ b/anatomy/track-tooling/test-runners/interface.md
@@ -62,6 +62,8 @@ This is an array of the test results, specified in the "Per-test" section below.
 The tests **MUST** be returned in the order they are specified in the tests file.
 For languages that execute tests in a random order, this may mean re-ordering the results in line with the order specified in the tests file.
 
+The rationale for this is that only the first failure is show to students and therefore it is important that the correct failure is shown. Because tests are generally ordered in that file in a TDD way, and because for Practice Exercises the students see the tests file in the editor, aligning the results with the file is critical.
+
 ### Per-test
 
 #### Name

--- a/anatomy/track-tooling/test-runners/interface.md
+++ b/anatomy/track-tooling/test-runners/interface.md
@@ -53,6 +53,15 @@ Where the status is `error` (the tests fail to execute cleanly), the top level `
 
 When the status is not `error`, either set the value to `null` or omit the key entirely.
 
+#### Tests
+
+> key: `tests`
+
+This is an array of the test results, specified in the "Per-test" section below.
+
+The tests **MUST** be returned in the order they are specified in the tests file.
+For languages that execute tests in a random order, this may mean re-ordering the results in line with the order specified in the tests file.
+
 ### Per-test
 
 #### Name


### PR DESCRIPTION
In the Research Site, the responsibly of ordering the tests lay with the website. It used the `config.json` file as its basis for ordering. Now that file has been deprecated, the responsibility for ordering moves to the individual test-runners.

I can't see a situation where a test-runner can't achieve this by reordering the tests based on grepping the file, but if anyone finds one, we can work out how to deal with it then.