### PR TITLE
Create markdown specification document

### DIFF
--- a/anatomy/tracks/configlet/linting.md
+++ b/anatomy/tracks/configlet/linting.md
@@ -190,15 +190,14 @@ The `config.json` file should have the following checks:
 
 ### Rule: exercises/concept/&lt;slug&gt;/.docs/hints.md is valid
 
-- If there are sub headings, they must start at level two
-- All headings must be level two headings
+- The Markdown must conform to the [Markdown standards](../../../contributing/standards/markdown.md)
 - All headings must be either `## General` or `## X. <task>` where `X` matches the task number heading in the `instructions.md`
 - All hints must be specified as Markdown list items
 - Links must be absolute (relative links are not allowed)
 
 ### Rule: exercises/concept/&lt;slug&gt;/.docs/instructions.md is valid
 
-- If there are sub headings, they must start at level two
+- The Markdown must conform to the [Markdown standards](../../../contributing/standards/markdown.md)
 - All tasks must start with a level two heading that starts with a number followed by a dot: `## 1. Do X`
 - Links must be absolute (relative links are not allowed)
 
@@ -208,27 +207,27 @@ The `config.json` file should have the following checks:
 
 ### Rule: exercises/concept/&lt;slug&gt;/.docs/introduction.md is valid
 
-- If there are sub headings, they must start at level two
+- The Markdown must conform to the [Markdown standards](../../../contributing/standards/markdown.md)
 - Links must be absolute (relative links are not allowed)
 
 ### Rule: exercises/shared/.docs/cli.md is valid
 
-- If there are sub headings, they must start at level two
+- The Markdown must conform to the [Markdown standards](../../../contributing/standards/markdown.md)
 - Links must be absolute (relative links are not allowed)
 
 ### Rule: exercises/shared/.docs/debug.md is valid
 
-- If there are sub headings, they must start at level two
+- The Markdown must conform to the [Markdown standards](../../../contributing/standards/markdown.md)
 - Links must be absolute (relative links are not allowed)
 
 ### Rule: concepts/&lt;slug&gt;/about.md is valid
 
-- If there are sub headings, they must start at level two
+- The Markdown must conform to the [Markdown standards](../../../contributing/standards/markdown.md)
 - Links must be absolute (relative links are not allowed)
 
 ### Rule: concepts/&lt;slug&gt;/introduction.md is valid
 
-- If there are sub headings, they must start at level two
+- The Markdown must conform to the [Markdown standards](../../../contributing/standards/markdown.md)
 - Links must be absolute (relative links are not allowed)
 
 ### Rule: concept/&lt;slug&gt;/links.json is valid

--- a/contributing/standards/markdown.md
+++ b/contributing/standards/markdown.md
@@ -8,7 +8,7 @@ All rules are being added to our CI and linting tools.
 
 ## Headings
 - All files must start start with a level-1 heading (`# Some heading text`). 
-- Level-1 headings exist purely for consuming on GitHub or equivelent.
+- Level-1 headings exist purely for consuming on GitHub or equivalent.
 - If the file is rendered on by the Exercism (e.g. displayed on the website, rendered via the CLI), this heading will be removed, and a contextual heading will be inserted.
 - No heading may decend a level greater than one below the previous (e.g. `##` may only be followed by `###`, not `####`)
 - Beyond the single level-1 (`#`) heading, only level-2 (`##`), level-3 (`###`) and level-4 (`####`) headings may be used.

--- a/contributing/standards/markdown.md
+++ b/contributing/standards/markdown.md
@@ -10,6 +10,6 @@ All rules are being added to our CI and linting tools.
 
 - All files must start start with a level-1 heading (`# Some heading text`).
 - Level-1 headings exist purely for consuming on GitHub or equivalent.
-- If the file is rendered on by the Exercism (e.g. displayed on the website, rendered via the CLI), this heading will be removed, and a contextual heading will be inserted.
+- If the file is rendered by Exercism (e.g. displayed on the website, rendered via the CLI), this heading will be removed, and a contextual heading will be inserted.
 - No heading may decend a level greater than one below the previous (e.g. `##` may only be followed by `###`, not `####`)
 - Beyond the single level-1 (`#`) heading, only level-2 (`##`), level-3 (`###`) and level-4 (`####`) headings may be used.

--- a/contributing/standards/markdown.md
+++ b/contributing/standards/markdown.md
@@ -1,0 +1,14 @@
+# Markdown Specification
+
+The following is the way that all Markdown files within Exercism should be structured.
+
+Some of the rules in this document are not yet implemented across Exercism. 
+We welcome PRs to fix them.
+All rules are being added to our CI and linting tools.
+
+## Headings
+- All files must start start with a level-1 heading (`# Some heading text`). 
+- Level-1 headings exist purely for consuming on GitHub or equivelent.
+- If the file is rendered on by the Exercism (e.g. displayed on the website, rendered via the CLI), this heading will be removed, and a contextual heading will be inserted.
+- No heading may decend a level greater than one below the previous (e.g. `##` may only be followed by `###`, not `####`)
+- Beyond the single level-1 (`#`) heading, only level-2 (`##`), level-3 (`###`) and level-4 (`####`) headings may be used.

--- a/contributing/standards/markdown.md
+++ b/contributing/standards/markdown.md
@@ -2,12 +2,13 @@
 
 The following is the way that all Markdown files within Exercism should be structured.
 
-Some of the rules in this document are not yet implemented across Exercism. 
+Some of the rules in this document are not yet implemented across Exercism.
 We welcome PRs to fix them.
 All rules are being added to our CI and linting tools.
 
 ## Headings
-- All files must start start with a level-1 heading (`# Some heading text`). 
+
+- All files must start start with a level-1 heading (`# Some heading text`).
 - Level-1 headings exist purely for consuming on GitHub or equivalent.
 - If the file is rendered on by the Exercism (e.g. displayed on the website, rendered via the CLI), this heading will be removed, and a contextual heading will be inserted.
 - No heading may decend a level greater than one below the previous (e.g. `##` may only be followed by `###`, not `####`)


### PR DESCRIPTION
This adds a markdown specification document. Please see https://github.com/exercism/configlet/issues/150#issuecomment-772762259 for the rationale of these choices.

(credit to @coriolinus for pushing on this)