### PR TITLE
configlet: fix example uuid command

### DIFF
--- a/anatomy/tracks/configlet/uuids.md
+++ b/anatomy/tracks/configlet/uuids.md
@@ -22,7 +22,7 @@ Global options:
 ## Example
 
 ```
-$ configlet uuid -num 5
+$ configlet uuid --num 5
 3823f890-be49-4700-baac-e19de8fda76f
 c12309a2-8bd6-4b9c-a511-e1ee4083f492
 26167ad5-fe20-43d4-8b1f-3bbb9618c36e


### PR DESCRIPTION
This should be a long option.

Previously this command caused an error, because `um` was parsed as an
argument to the `-n` option:
```
$ configlet uuid -num 5
Error: value for '-n' is not a positive integer: um
```

Abbreviated usage for configlet:
```
Usage:
  configlet [global-options] <command> [command-options]

Commands:
  lint, sync, uuid

Options for uuid:
  -n, --num <int>              Number of UUIDs to generate
```