### PR TITLE
Add info on practices and prereqs keys

### DIFF
--- a/anatomy/tracks/practice-exercises.md
+++ b/anatomy/tracks/practice-exercises.md
@@ -25,6 +25,23 @@ Practice Exercise metadata is defined in the `exercises.practice` key in the [co
 }
 ```
 
+### `practices`
+
+The `practices` key should list the slugs of Concepts that this Practice Exericse actively allows a student to practice. 
+
+- These show up in the UI as "Practice this Concept in: TwoFer, Leap, etc`
+- Try and choose 3 - 8 Exercises for this key.
+- Try and choose at least two Exercises that allow someone to practice the basics of a Concept.
+- Some Concepts are very common (for example `strings` or `integers`). In those cases we recommend choosing a few good exercises that make people think about those Concepts in interesting ways. For example, exercises that require utf8, string concatenation, char enumeration, base-changes, etc, would all be good examples.
+
+### `prerequisites`
+
+The `prerequisites` key lists the Concept Exercises that a student must have completed in order to access this Practice Exercise. 
+
+- These show up in the UI as "Learn Strings to unlock TwoFer"
+- It should include all Concepts that a student needs to have covered to be able to complete the exercise in at least one idiomatic way. For example, for the TwoFer exercise in Ruby, prerequisites might include `strings`, `optional-params`, `implicit-return`. 
+- For Exercises that can be completed using alternative Concepts (e.g. an Exercise solvable by `loops` or `recursion`), the maintainer should choose the approach that they would like to unlock the Exercise, considering the student's journey through the track.
+
 ## Files
 
 Each Practice Exercise has its own directory within the track's `exercises/practice` directory. The name of the Practice Exercise directory must match the `slug` property of the Practice Exercise, as defined in the [config.json file](./config-json.md#concept-exercises).

--- a/anatomy/tracks/practice-exercises.md
+++ b/anatomy/tracks/practice-exercises.md
@@ -30,7 +30,7 @@ Practice Exercise metadata is defined in the `exercises.practice` key in the [co
 The `practices` key should list the slugs of Concepts that this Practice Exericse actively allows a student to practice. 
 
 - These show up in the UI as "Practice this Concept in: TwoFer, Leap, etc`
-- Try and choose 3 - 8 Exercises for this key.
+- Try and choose 3 - 8 Exercises that practice each Concept.
 - Try and choose at least two Exercises that allow someone to practice the basics of a Concept.
 - Some Concepts are very common (for example `strings` or `integers`). In those cases we recommend choosing a few good exercises that make people think about those Concepts in interesting ways. For example, exercises that require utf8, string concatenation, char enumeration, base-changes, etc, would all be good examples.
 

--- a/anatomy/tracks/practice-exercises.md
+++ b/anatomy/tracks/practice-exercises.md
@@ -27,7 +27,7 @@ Practice Exercise metadata is defined in the `exercises.practice` key in the [co
 
 ### `practices`
 
-The `practices` key should list the slugs of Concepts that this Practice Exericse actively allows a student to practice. 
+The `practices` key should list the slugs of Concepts that this Practice Exercise actively allows a student to practice. 
 
 - These show up in the UI as "Practice this Concept in: TwoFer, Leap, etc`
 - Try and choose 3 - 8 Exercises that practice each Concept.

--- a/anatomy/tracks/practice-exercises.md
+++ b/anatomy/tracks/practice-exercises.md
@@ -32,7 +32,7 @@ The `practices` key should list the slugs of Concepts that this Practice Exercis
 - These show up in the UI as "Practice this Concept in: TwoFer, Leap, etc"
 - Try and choose 3 - 8 Exercises that practice each Concept.
 - Try and choose at least two Exercises that allow someone to practice the basics of a Concept.
-- Some Concepts are very common (for example `strings` or `integers`). In those cases we recommend choosing a few good exercises that make people think about those Concepts in interesting ways. For example, exercises that require utf8, string concatenation, char enumeration, base-changes, etc, would all be good examples.
+- Some Concepts are very common (for example `strings`). In those cases we recommend choosing a few good exercises that make people think about those Concepts in interesting ways. For example, exercises that require UTF-8, string concatenation, char enumeration, etc, would all be good examples.
 
 ### `prerequisites`
 

--- a/anatomy/tracks/practice-exercises.md
+++ b/anatomy/tracks/practice-exercises.md
@@ -40,7 +40,7 @@ The `prerequisites` key lists the Concept Exercises that a student must have com
 
 - These show up in the UI as "Learn Strings to unlock TwoFer"
 - It should include all Concepts that a student needs to have covered to be able to complete the exercise in at least one idiomatic way. For example, for the TwoFer exercise in Ruby, prerequisites might include `strings`, `optional-params`, `implicit-return`. 
-- For Exercises that can be completed using alternative Concepts (e.g. an Exercise solvable by `loops` or `recursion`), the maintainer should choose the approach that they would like to unlock the Exercise, considering the student's journey through the track.
+- For Exercises that can be completed using alternative Concepts (e.g. an Exercise solvable by `loops` or `recursion`), the maintainer should choose the one approach that they would like to unlock the Exercise, considering the student's journey through the track. For example, the loops/recursion example, they might think this exercise is a good early practice of `loops` or that they might like to leave it later to teach recursion. They can also make use of an analyzer to prompt the student to try an alternative approach: "Nice work on solving this via loops. You might also like to try solving this using Recursion."
 
 ## Files
 

--- a/anatomy/tracks/practice-exercises.md
+++ b/anatomy/tracks/practice-exercises.md
@@ -29,7 +29,7 @@ Practice Exercise metadata is defined in the `exercises.practice` key in the [co
 
 The `practices` key should list the slugs of Concepts that this Practice Exercise actively allows a student to practice. 
 
-- These show up in the UI as "Practice this Concept in: TwoFer, Leap, etc`
+- These show up in the UI as "Practice this Concept in: TwoFer, Leap, etc"
 - Try and choose 3 - 8 Exercises that practice each Concept.
 - Try and choose at least two Exercises that allow someone to practice the basics of a Concept.
 - Some Concepts are very common (for example `strings` or `integers`). In those cases we recommend choosing a few good exercises that make people think about those Concepts in interesting ways. For example, exercises that require utf8, string concatenation, char enumeration, base-changes, etc, would all be good examples.


### PR DESCRIPTION
We should also link back here from https://github.com/exercism/docs/blob/main/anatomy/tracks/config-json.md#practice-exercises. I think this belongs better in this document where someone is in the mindset of thinking about Practice Exercises.