### PR TITLE
Add h1 headings to Markdown example

### DIFF
--- a/anatomy/tracks/concept-exercises.md
+++ b/anatomy/tracks/concept-exercises.md
@@ -91,6 +91,8 @@ As an example, the introduction to a "strings" exercise might describe a string 
 #### Example
 
 ````markdown
+# Introduction
+
 There are two primary ways to assign objects to names in Ruby - using variables or constants. Variables are always written in snake case. A variable can reference different objects over its lifetime. For example, `my_first_variable` can be defined and redefined many times using the `=` operator:
 
 ```ruby
@@ -121,6 +123,8 @@ Tracks can decide per exercise whether to use a template or not. In some cases, 
 #### Example
 
 ```markdown
+# Introduction
+
 %{concept:variables}
 ```
 
@@ -153,6 +157,8 @@ We place high value on making Exercism's content safe for everyone and so often 
 #### Example
 
 ````markdown
+# Instructions
+
 In this exercise you're going to write some code to help you cook a brilliant lasagna from your favorite cooking book.
 
 ## 1. Calculate the remaining oven time in minutes
@@ -192,6 +198,8 @@ Viewing hints will not be a "recommended" path and we will (softly) discourage u
 #### Example
 
 ```markdown
+# Hints
+
 ## General
 
 - You need to define a [constant][constant] which should contain the [integer][integers] value specified in the recipe.
@@ -220,6 +228,8 @@ It exists in order to inform future maintainers or contributors about the scope 
 #### Example
 
 ```markdown
+# Design
+
 ## Goal
 
 The goal of this exercise is to teach the student the basics of programming in Ruby.

--- a/anatomy/tracks/concepts.md
+++ b/anatomy/tracks/concepts.md
@@ -60,6 +60,8 @@ This document can also link to any additional resources that might be interestin
 #### Example
 
 ````markdown
+# About
+
 One of the key aspects of working with numbers in C# is the distinction between [integers](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/integral-numeric-types) (numbers with no digits after the decimal separator) and [floating-point numbers](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/floating-point-numeric-types) (numbers with zero or more digits after the decimal separator).
 
 The two most commonly used numeric types in C# are `int` (a 32-bit integer) and `double` (a 64-bit floating-point number).
@@ -96,6 +98,8 @@ This file is shown if a student has not yet completed the corresponding concept 
 #### Example
 
 ````markdown
+# Introduction
+
 One of the key aspects of working with numbers in C# is the distinction between integers and floating-point numbers (numbers with zero or more digits after the decimal separator).
 
 The two most commonly used numeric types in C# are `int` (a 32-bit integer) and `double` (a 64-bit floating-point number).

--- a/anatomy/tracks/practice-exercises.md
+++ b/anatomy/tracks/practice-exercises.md
@@ -27,7 +27,7 @@ Practice Exercise metadata is defined in the `exercises.practice` key in the [co
 
 ### `practices`
 
-The `practices` key should list the slugs of Concepts that this Practice Exercise actively allows a student to practice. 
+The `practices` key should list the slugs of Concepts that this Practice Exercise actively allows a student to practice.
 
 - These show up in the UI as "Practice this Concept in: TwoFer, Leap, etc"
 - Try and choose 3 - 8 Exercises that practice each Concept.
@@ -36,10 +36,10 @@ The `practices` key should list the slugs of Concepts that this Practice Exercis
 
 ### `prerequisites`
 
-The `prerequisites` key lists the Concepts that a student must have completed in order to access this Practice Exercise. 
+The `prerequisites` key lists the Concepts that a student must have completed in order to access this Practice Exercise.
 
 - These show up in the UI as "Learn Strings to unlock TwoFer"
-- It should include all Concepts that a student needs to have covered to be able to complete the exercise in at least one idiomatic way. For example, for the TwoFer exercise in Ruby, prerequisites might include `strings`, `optional-params`, `implicit-return`. 
+- It should include all Concepts that a student needs to have covered to be able to complete the exercise in at least one idiomatic way. For example, for the TwoFer exercise in Ruby, prerequisites might include `strings`, `optional-params`, `implicit-return`.
 - For Exercises that can be completed using alternative Concepts (e.g. an Exercise solvable by `loops` or `recursion`), the maintainer should choose the one approach that they would like to unlock the Exercise, considering the student's journey through the track. For example, the loops/recursion example, they might think this exercise is a good early practice of `loops` or that they might like to leave it later to teach recursion. They can also make use of an analyzer to prompt the student to try an alternative approach: "Nice work on solving this via loops. You might also like to try solving this using Recursion."
 
 ## Files
@@ -113,6 +113,8 @@ We place high value on making Exercism's content safe for everyone and so often 
 #### Example
 
 ```markdown
+# Introduction
+
 Bob is a lackadaisical teenager. In conversation, his responses are very limited.
 ```
 
@@ -129,6 +131,8 @@ In some (rare) cases, you might want to expand on the exercise's `introduction.m
 A track that doesn't want Bob to support, might add the following:
 
 ```markdown
+# Introduction append
+
 As part of his teenage rebellion, Bob has decided to only communicate using ASCII.
 ```
 
@@ -151,6 +155,8 @@ We place high value on making Exercism's content safe for everyone and so often 
 #### Example
 
 ```markdown
+# Instructions
+
 Bob answers 'Sure.' if you ask him a question, such as "How are you?".
 
 He answers 'Whoa, chill out!' if you YELL AT HIM (in all capitals).
@@ -171,6 +177,8 @@ He answers 'Whatever.' to anything else.
 In some (rare) cases, you might want to expand on the exercise's `instructions.md` file, for example when the exercise has implemented tests that are not covered by the existing instructions.
 
 ```markdown
+# Instructions append
+
 Bob's conversational partner is a purist when it comes to written communication and always follows normal rules regarding sentence punctuation in English.
 ```
 
@@ -215,6 +223,8 @@ It exists in order to inform future maintainers or contributors about the scope 
 #### Example
 
 ```markdown
+# Design
+
 ## Goal
 
 The goal of this exercise is help students practice how to work with strings.

--- a/anatomy/tracks/presentation.md
+++ b/anatomy/tracks/presentation.md
@@ -40,13 +40,19 @@ When working locally via the CLI, we don't have the option to conditionally show
 ## Exercise-specific files
 
 # .docs/introduction.md
-"This is the introduction."
+"# Introduction
+
+This is the introduction."
 
 # .docs/instructions.md
-"These are the instructions."
+"# Instructions
+
+These are the instructions."
 
 # .docs/hints.md
-"## General
+"# Hints
+
+## General
 
 - Consider extracting the logic to a helper function."
 
@@ -56,21 +62,31 @@ When working locally via the CLI, we don't have the option to conditionally show
 ## Track-specific files
 
 # debug.md
-"This is how to do debugging."
+"# Debug
+
+This is how to do debugging."
 
 # help.md
-"This is how to get track-specific help."
+"# Help
+
+This is how to get track-specific help."
 
 # tests.md
-"This is how to run the tests for this track."
+"# Tests
+
+This is how to run the tests for this track."
 
 ## Exercism-wide files
 
 # cli.md
-"This is how to submit the solution."
+"# CLI
+
+This is how to submit the solution."
 
 # help.md
-"This is how to get Exercism-wide help."
+"# Help
+
+This is how to get Exercism-wide help."
 ```
 
 ### Editor
@@ -116,6 +132,8 @@ TODO: verify that this is the correct format
 This is the contents of the generated `HINTS.md` file:
 
 ```markdown
+# Hints
+
 ## General
 
 - Consider extracting the logic to a helper function.
@@ -129,10 +147,14 @@ For this example, we'll re-use the documentation files from the [above example](
 ## Exercise-specific files
 
 # .docs/introduction.append.md
-"Append to the introduction."
+"# Introduction append
+
+Append to the introduction."
 
 # .docs/instructions.append.md
-"Append to the instructions."
+"# Instructions append
+
+Append to the instructions."
 
 # .meta/config.json
 { "source": "Wikipedia", "source_url": "https://en.wikipedia.org/wiki/Lasagne"}`

--- a/anatomy/tracks/shared-files.md
+++ b/anatomy/tracks/shared-files.md
@@ -41,6 +41,8 @@ The in-browser editor does not have any built-in debugging support. If the track
 #### Example
 
 ````markdown
+# Debug
+
 To help with debugging, you can use the fact that any [console output](https://www.programiz.com/csharp-programming/basic-input-output) will be shown in the test results window. You can write to the console using:
 
 ```csharp
@@ -59,6 +61,8 @@ Describe how a student can get help, specifically for this track (not Exercism-w
 #### Example
 
 ```markdown
+# Help
+
 If you're having trouble, feel free to ask help in the C# track's [gitter channel](https://gitter.im/exercism/csharp).
 ```
 
@@ -73,5 +77,7 @@ Describe how to run the tests for this particular exercise.
 #### Example
 
 ```markdown
+# Tests
+
 To run the tests, run the command `dotnet test` from within the exercise directory.
 ```


### PR DESCRIPTION
The Markdown examples did not yet contain the h1 headings.