### PR TITLE
Add extra new fields to analyzer spec

### DIFF
--- a/anatomy/track-tooling/analyzers/interface.md
+++ b/anatomy/track-tooling/analyzers/interface.md
@@ -22,31 +22,63 @@ The `analysis.json` file should be structured as followed:
 ```json
 {
   "status": "...",
+  "summary": "This solution looks good but has a few points to address",
   "comments": [
     {
       "comment": "ruby.general.some_paramaterised_message",
-      "params": { "foo": "param1", "bar": "param2" }
+      "params": { "foo": "param1", "bar": "param2" },
+      "type": "essential"
     },
     {
-      "comment": "ruby.general.some_paramaterised_message",
-      "params": {}
+      "comment": "ruby.general.some_unparamaterised_message",
+      "params": {},
+      "type": "actionable"
     },
     {
-      "comment": "ruby.general.some_paramaterised_message"
+      "comment": "ruby.general.some_unparamaterised_message"
     },
-    "ruby.general.some_paramaterised_message"
+    "ruby.general.some_unparamaterised_message"
   ]
 }
 ```
 
-Messages are keys into `website-copy/automated-comments/`, e.g. [`ruby.general.explicit_return -> automated-comments/ruby/general/explicit_return.md`](https://github.com/exercism/website-copy/blob/47af5b309ac263629ca5c52904046f81e0cc8def/automated-comments/ruby/general/explicit_return.md).
-Those markdown files can be parameterized with strings like this `Try %{variable_name} += 1 instead`.
 
-The following statuses are valid:
+### `summary` (optional)
 
-- `approve`: To be used when a solution can be approved.
-- `disapprove`: To be used when a solution can be disapproved as suboptimal and a comment is provided.
-- `refer_to_mentor`: This is the default situation and should be used when there is any uncertainty.
+The summary field is a text field that summarises the output. 
+It might say something like "Your solution is nearly there - there's just two small changes you can make." or "The code works great, but there's a little bit of linting that needs doing.".
+This summary is rendered on the website above the comments.
+
+
+### `comments`
+Comments are keys into `website-copy/automated-comments/`, e.g. [`ruby.general.explicit_return -> automated-comments/ruby/general/explicit_return.md`](https://github.com/exercism/website-copy/blob/47af5b309ac263629ca5c52904046f81e0cc8def/automated-comments/ruby/general/explicit_return.md).
+
+Then can be structured either as single pointer strings (e.g. the last example above) or using a JSON Object to specify the follow keys:
+
+#### `comment`
+
+The pointer-string to a file in `website-copy`
+
+#### `params` (optional)
+
+A JSON Object containing any params that should be interpolated during rendering. 
+For example, in the markdown file, you could write `Try %{variable_name} += 1 instead`, and then use `params` to substitute `%{variable_name}` for the actual variable that the student used.
+
+When using paramaterised files, ensure to escape all uses of `%` but placing anohter `%` in front of it. 
+e.g. `Try aim aim for 100%% of the tests passing`.
+
+#### `type` (optional)
+The following `type`s are valid:
+
+- `essential`: We will soft-block students until they have addressed this comment
+- `actionable`: Any comment that gives a specific instruction to a user to improve their solution
+- `informative`: Comments that give information, but do not necessarily expect students to use it. For example, in Ruby, if someone uses String Concatenation in TwoFer, we also tell them about String Formatting, but don't suggest that it is a better option.
+- `celebratory`: Comments that tell users they've done something right, either as a general comment on the solution, or on a technique. 
+
+Comments without a type field default to `actionable`.
+
+Currently in the website, we soft-block on essential comments, encourage students to complete actionable comments before marking as complete on Practice Exercises (but not Concept Exercises), but don't suggest any action on `informative` or `celebratory`. 
+However, in future we may choose to add emojis or indicators to other types, or group them seperately.
 
 ## Debugging
 

--- a/anatomy/track-tooling/analyzers/interface.md
+++ b/anatomy/track-tooling/analyzers/interface.md
@@ -61,7 +61,7 @@ The pointer-string to a file in `website-copy`.
 #### `params` (optional)
 
 A JSON Object containing any params that should be interpolated during rendering. 
-For example, in the markdown file, you could write `Try %{variable_name} += 1 instead`, and then use `params` to substitute `%{variable_name}` for the actual variable that the student used.
+For example, in the markdown file, you could write `Try %{variable_name} += 1 instead`, and then set `params` to `{ "variable_name": "foo"}` in order to substitute `%{variable_name}` for the actual variable that the student used.
 
 When using parameterised files, ensure to escape all uses of `%` by placing anther `%` in front of it. 
 e.g. `Try aim aim for 100%% of the tests passing`.

--- a/anatomy/track-tooling/analyzers/interface.md
+++ b/anatomy/track-tooling/analyzers/interface.md
@@ -49,7 +49,6 @@ The summary field is a text field that summarises the output.
 It might say something like "Your solution is nearly there - there's just two small changes you can make." or "The code works great, but there's a little bit of linting that needs doing.".
 This summary is rendered on the website above the comments.
 
-
 ### `comments`
 Comments are keys into `website-copy/automated-comments/`, e.g. [`ruby.general.explicit_return -> automated-comments/ruby/general/explicit_return.md`](https://github.com/exercism/website-copy/blob/47af5b309ac263629ca5c52904046f81e0cc8def/automated-comments/ruby/general/explicit_return.md).
 

--- a/anatomy/track-tooling/analyzers/interface.md
+++ b/anatomy/track-tooling/analyzers/interface.md
@@ -74,7 +74,7 @@ The following `type`s are valid:
 - `informative`: Comments that give information, but do not necessarily expect students to use it. For example, in Ruby, if someone uses String Concatenation in TwoFer, we also tell them about String Formatting, but don't suggest that it is a better option.
 - `celebratory`: Comments that tell users they've done something right, either as a general comment on the solution, or on a technique. 
 
-Comments without a type field default to `actionable`.
+Comments without a type field default to `informative `.
 
 Currently in the website, we soft-block on essential comments, encourage students to complete actionable comments before marking as complete on Practice Exercises (but not Concept Exercises), but don't suggest any action on `informative` or `celebratory`. 
 However, in the future we may choose to add emojis or indicators to other types, or group them seperately.

--- a/anatomy/track-tooling/analyzers/interface.md
+++ b/anatomy/track-tooling/analyzers/interface.md
@@ -25,19 +25,19 @@ The `analysis.json` file should be structured as followed:
   "summary": "This solution looks good but has a few points to address",
   "comments": [
     {
-      "comment": "ruby.general.some_paramaterised_message",
+      "comment": "ruby.general.some_parameterised_message",
       "params": { "foo": "param1", "bar": "param2" },
       "type": "essential"
     },
     {
-      "comment": "ruby.general.some_unparamaterised_message",
+      "comment": "ruby.general.some_unparameterised_message",
       "params": {},
       "type": "actionable"
     },
     {
-      "comment": "ruby.general.some_unparamaterised_message"
+      "comment": "ruby.general.some_unparameterised_message"
     },
-    "ruby.general.some_unparamaterised_message"
+    "ruby.general.some_unparameterised_message"
   ]
 }
 ```
@@ -56,14 +56,14 @@ Then can be structured either as single pointer strings (e.g. the last example a
 
 #### `comment`
 
-The pointer-string to a file in `website-copy`
+The pointer-string to a file in `website-copy`.
 
 #### `params` (optional)
 
 A JSON Object containing any params that should be interpolated during rendering. 
 For example, in the markdown file, you could write `Try %{variable_name} += 1 instead`, and then use `params` to substitute `%{variable_name}` for the actual variable that the student used.
 
-When using paramaterised files, ensure to escape all uses of `%` but placing anohter `%` in front of it. 
+When using parameterised files, ensure to escape all uses of `%` by placing anther `%` in front of it. 
 e.g. `Try aim aim for 100%% of the tests passing`.
 
 #### `type` (optional)
@@ -77,7 +77,7 @@ The following `type`s are valid:
 Comments without a type field default to `actionable`.
 
 Currently in the website, we soft-block on essential comments, encourage students to complete actionable comments before marking as complete on Practice Exercises (but not Concept Exercises), but don't suggest any action on `informative` or `celebratory`. 
-However, in future we may choose to add emojis or indicators to other types, or group them seperately.
+However, in the future we may choose to add emojis or indicators to other types, or group them seperately.
 
 ## Debugging
 


### PR DESCRIPTION
This PR brings the spec in line with where we want it to be for v3 launch. All the changes are "additive", meaning that v2 analyzer will still work fine in v3, but that this gives maintainers some extra firepower should they want it.

- Adds top-level `summary`
- Adds `type` fields to `comments`
- Fills in some missing information for existing fields

I'll add screenshots to this file in a separate PR when they're ready.