### PR TITLE
Document editor files

### DIFF
--- a/anatomy/tracks/concept-exercises.md
+++ b/anatomy/tracks/concept-exercises.md
@@ -275,6 +275,7 @@ This file contains meta information on the exercise:
   - `solution`: the [stub implementation file(s)](./#filestubimplementation) (required)
   - `test`: the [test file(s)](./#filetests) (required)
   - `exemplar`: the [exemplar implementation file(s)](./#fileexemplarimplementation) (required)
+  - `editor`: other files shown as read-only in the editor (optional)
 - `language_versions`: Language version requirements (optional)
 - `source`: The source this exercise is based on (optional)
 - `source_url`: The URL of the source this exercise is based on (optional)
@@ -320,7 +321,8 @@ Assume that the user FSharpForever has written an exercise called `basics` for t
   "files": {
     "solution": ["lasagna.py"],
     "test": ["lasagna_test.py"],
-    "exemplar": [".meta/exemplar.py"]
+    "exemplar": [".meta/exemplar.py"],
+    "editor": ["test_helper.py"]
   },
   "forked_from": ["fsharp/basics"],
   "language_versions": ">=3.7",

--- a/anatomy/tracks/config-json.md
+++ b/anatomy/tracks/config-json.md
@@ -24,6 +24,7 @@ The following top-level properties contain general track metadata:
   - `test`: test file(s) pattern (optional)
   - `example`: example implementation file(s) pattern (optional
   - `exemplar`: exemplar implementation file(s) pattern (optional)
+  - `editor`: additional read-only editor file(s) patterns (optional)
 
 ### Files
 

--- a/anatomy/tracks/practice-exercises.md
+++ b/anatomy/tracks/practice-exercises.md
@@ -252,6 +252,7 @@ This file contains meta information on the exercise:
   - `solution`: the [stub implementation file(s)](./#filestubimplementation) (required)
   - `test`: the [test file(s)](./#filetests) (required)
   - `example`: the [example implementation file(s)](./#fileexampleimplementation) (required)
+  - `editor`: additional files shown as read-only in the editor (optional)
 - `language_versions` Language version requirements (optional)
 - `source`: The source this exercise is based on (optional)
 - `source_url`: The URL of the source this exercise is based on (optional)


### PR DESCRIPTION
Some tracks have expressed a desire to show additional files to the student when working in the online editor. These files are not part of the solution, but are still relevant to solving the exercise. For this, we're adding the `files.editor` key. Any files in this key will be displayed as read-only files in the editor.
