### PR TITLE
Add missing "non-blank" linting rule

### DIFF
--- a/building/configlet/lint.md
+++ b/building/configlet/lint.md
@@ -116,7 +116,7 @@ The `config.json` file should have the following checks:
 - The `"exercises.practice[].practices"` key is required
 - The `"exercises.practice[].practices"` value must be a non-empty array of strings if `"exercises.practice[].status"` is not equal to `deprecated`
 - The `"exercises.practice[].practices"` value must be an empty array if `"exercises.practice[].status"` is equal to `deprecated`
-- The `"exercises.practice[].practices"` values must be non-empty, lowercased strings using kebab-case
+- The `"exercises.practice[].practices"` values must be non-empty, non-blank, lowercased strings using kebab-case
 - The `"exercises.practice[].practices"` values must not have duplicates
 - The `"exercises.practice[].practices"` values must match the `"concepts[].slug"` property of one of the concepts
 - The `"exercises.practice[].practices"` values must refer to an individual concept's slug at most 10 times (across all exercises)


### PR DESCRIPTION
With this PR, we now specify in `lint.md` that all kebab strings are non-blank:
```
$ git grep --break --heading 'kebab'
building/configlet/lint.md
52:- The `"slug"` value must be a non-empty, non-blank, lowercased string using kebab-case
75:- The `"exercises.concept[].slug"` value must be a non-empty, non-blank, lowercased string using kebab-case
87:- The `"exercises.concept[].concepts"` values must be non-empty, non-blank, lowercased strings using kebab-case
94:- The `"exercises.concept[].prerequisites"` values must be non-empty, non-blank, lowercased strings using kebab-case
105:- The `"exercises.practice[].slug"` value must be a non-empty, non-blank, lowercased string using kebab-case
119:- The `"exercises.practice[].practices"` values must be non-empty, non-blank, lowercased strings using kebab-case
126:- The `"exercises.practice[].prerequisites"` values must be non-empty, non-blank, lowercased strings using kebab-case
134:- The `"exercises.foregone"` values must be non-empty, non-blank, lowercased strings using kebab-case
142:- The `"concepts[].slug"` value must be a non-empty, non-blank, lowercased string using kebab-case

building/tracks/concept-exercises.md
476:1. Use [kebab-case][kebab-case].
489:- `TimFromMarketing`: does not use kebab-case (i.e. `tim-from-marketing`)
496:[kebab-case]: https://en.wiktionary.org/wiki/kebab_case

building/tracks/config-json.md
10:- `slug`: the track's language as a lowercased, kebab-case string (e.g. `"csharp"`) (required)
35:- `%{kebab_slug}`: the `kebab-case` exercise slug (e.g. `bit-manipulation`)
83:- `slug`: the exercise's slug, which is a lowercased, kebab-case string. The slug must be unique across all concept _and_ practice exercise slugs within the track
137:- `slug`: the exercise's slug, which is a lowercased, kebab-case string. The slug must be unique across all concept _and_ practice exercise slugs within the track
215:- `slug`: the concept's slug, which is a lowercased, kebab-case string. The slug must be unique across all concepts within the track
```