### PR TITLE
Centralize some string definitions in the linting rules

### DIFF
--- a/building/configlet/lint.md
+++ b/building/configlet/lint.md
@@ -49,7 +49,7 @@ The `config.json` file should have the following checks:
 - The `"language"` key is required
 - The `"language"` value must be a non-trivial string¹
 - The `"slug"` key is required
-- The `"slug"` value must be a non-empty, non-blank, lowercased string using kebab-case
+- The `"slug"` value must be a kebab-case string²
 - The `"active"` key is required
 - The `"active"` value must be a boolean
 - The `"blurb"` key is required
@@ -72,7 +72,7 @@ The `config.json` file should have the following checks:
 - The `"exercises.concept"` key is required
 - The `"exercises.concept"` value must be an array
 - The `"exercises.concept[].slug"` key is required
-- The `"exercises.concept[].slug"` value must be a non-empty, non-blank, lowercased string using kebab-case
+- The `"exercises.concept[].slug"` value must be a kebab-case string²
 - The `"exercises.concept[].slug"` value must be unique in `"exercises.concept[].slug"` and may not exist in `"exercises.practice[].slug"`
 - The `"exercises.concept[].name"` key is required
 - The `"exercises.concept[].name"` value must be a non-trivial string¹
@@ -84,14 +84,14 @@ The `config.json` file should have the following checks:
 - The `"exercises.concept[].concepts"` key is required
 - The `"exercises.concept[].concepts"` value must be a non-empty array of strings if `"exercises.concept[].status"` is not equal to `deprecated`
 - The `"exercises.concept[].concepts"` value must be an empty array if `"exercises.concept[].status"` is equal to `deprecated`
-- The `"exercises.concept[].concepts"` values must be non-empty, non-blank, lowercased strings using kebab-case
+- The `"exercises.concept[].concepts"` values must be kebab-case strings²
 - The `"exercises.concept[].concepts"` values must not have duplicates
 - The `"exercises.concept[].concepts"` values must not be in any other concept exercise's `"concepts"` property
 - The `"exercises.concept[].concepts"` values must match the `"concepts.slug"` property of one of the concepts
 - The `"exercises.concept[].prerequisites"` key is required
 - The `"exercises.concept[].prerequisites"` value must be a non-empty array of strings if `"exercises.concept[].status"` is not equal to `deprecated`, except for exactly one exercise which _is_ allowed to have an empty array as its value
 - The `"exercises.concept[].prerequisites"` value must be an empty array if `"exercises.concept[].status"` is equal to `deprecated`
-- The `"exercises.concept[].prerequisites"` values must be non-empty, non-blank, lowercased strings using kebab-case
+- The `"exercises.concept[].prerequisites"` values must be kebab-case strings²
 - The `"exercises.concept[].prerequisites"` values must not have duplicates
 - The `"exercises.concept[].prerequisites"` values must match any other concept exercise's `"concepts"` property values
 - The `"exercises.concept[].prerequisites"` values must not match any of the values in the exercise's `"exercises.concept[].concepts"` property
@@ -102,7 +102,7 @@ The `config.json` file should have the following checks:
 - The `"exercises.practice"` key is required
 - The `"exercises.practice"` value must be an array
 - The `"exercises.practice[].slug"` key is required
-- The `"exercises.practice[].slug"` value must be a non-empty, non-blank, lowercased string using kebab-case
+- The `"exercises.practice[].slug"` value must be a kebab-case string²
 - The `"exercises.practice[].slug"` value must be unique in `"exercises.practice[].slug"` and may not exist in `"exercises.concept[].slug"`
 - The `"exercises.practice[].name"` key is required
 - The `"exercises.practice[].name"` value must be a non-trivial string¹
@@ -116,14 +116,14 @@ The `config.json` file should have the following checks:
 - The `"exercises.practice[].practices"` key is required
 - The `"exercises.practice[].practices"` value must be a non-empty array of strings if `"exercises.practice[].status"` is not equal to `deprecated`
 - The `"exercises.practice[].practices"` value must be an empty array if `"exercises.practice[].status"` is equal to `deprecated`
-- The `"exercises.practice[].practices"` values must be non-empty, lowercased strings using kebab-case
+- The `"exercises.practice[].practices"` values must be kebab-case strings²
 - The `"exercises.practice[].practices"` values must not have duplicates
 - The `"exercises.practice[].practices"` values must match the `"concepts[].slug"` property of one of the concepts
 - The `"exercises.practice[].practices"` values must refer to an individual concept's slug at most 10 times (across all exercises)
 - The `"exercises.practice[].prerequisites"` key is required
 - The `"exercises.practice[].prerequisites"` value must be a non-empty array of strings if `"exercises.practice[].status"` is not equal to `deprecated`
 - The `"exercises.practice[].prerequisites"` value must be an empty array if `"exercises.practice[].status"` is equal to `deprecated`
-- The `"exercises.practice[].prerequisites"` values must be non-empty, non-blank, lowercased strings using kebab-case
+- The `"exercises.practice[].prerequisites"` values must be kebab-case strings²
 - The `"exercises.practice[].prerequisites"` values must not have duplicates
 - The `"exercises.practice[].prerequisites"` values must match any concept exercise's `"exercises.concept[].concepts"` values
 - The `"exercises.practice[].prerequisites"` values must match the `"concepts[].slug"` property of one of the concepts
@@ -131,7 +131,7 @@ The `config.json` file should have the following checks:
 - The `"exercises.practice[].status"` value must be the string `wip`, `beta`, `active` or `deprecated`
 - The `"exercises.foregone"` key is optional
 - The `"exercises.foregone"` value must be an array
-- The `"exercises.foregone"` values must be non-empty, non-blank, lowercased strings using kebab-case
+- The `"exercises.foregone"` values must be kebab-case strings²
 - The `"exercises.foregone"` values must not match any of the concept or practice exercise slugs
 - The `"concepts"` key is required
 - The `"concepts"` value must be an array
@@ -139,7 +139,7 @@ The `config.json` file should have the following checks:
 - The `"concepts[].uuid"` key is required
 - The `"concepts[].uuid"` value must be a unique, lowercased v4 UUID string
 - The `"concepts[].slug"` key is required
-- The `"concepts[].slug"` value must be a non-empty, non-blank, lowercased string using kebab-case
+- The `"concepts[].slug"` value must be a kebab-case string²
 - The `"concepts[].name"` key is required
 - The `"concepts[].name"` value must be a non-empty, non-blank, titleized string
 - Each `"concepts"` value must have a `concept/<concepts.slug>/about.md` file. Linting rules for this file are specified below.
@@ -296,4 +296,4 @@ The `config.json` file should have the following checks:
 ## Glossary
 
 1. Non-trivial string: a string that has at least one non-whitespace character.
-- _kebab_case_: strings containing only characters in the range `[a-z0-9]` optionally separated by dashes (e.g. "two-fer"). In regular expression format: `^[a-z0-9]+(-[a-z0-9]+)*$`
+2. kebab-case string: a string that contains only characters in the range `[a-z0-9]`, optionally separated by dashes (e.g. "two-fer"). It must match the regular expression: `^[a-z0-9]+(-[a-z0-9]+)*$`

--- a/building/configlet/lint.md
+++ b/building/configlet/lint.md
@@ -47,13 +47,13 @@ The `config.json` file should have the following checks:
 
 - The file must be valid JSON
 - The `"language"` key is required
-- The `"language"` value must be a non-trivial string¹
+- The `"language"` value must be a non-blank string¹
 - The `"slug"` key is required
 - The `"slug"` value must be a kebab-case string²
 - The `"active"` key is required
 - The `"active"` value must be a boolean
 - The `"blurb"` key is required
-- The `"blurb"` value must be a non-trivial string¹ with length <= 400
+- The `"blurb"` value must be a non-blank string¹ with length <= 400
 - The `"version"` key is required
 - The `"version"` value must be the integer `3`
 - The `"status.concept_exercises"` key is required
@@ -75,7 +75,7 @@ The `config.json` file should have the following checks:
 - The `"exercises.concept[].slug"` value must be a kebab-case string²
 - The `"exercises.concept[].slug"` value must be unique in `"exercises.concept[].slug"` and may not exist in `"exercises.practice[].slug"`
 - The `"exercises.concept[].name"` key is required
-- The `"exercises.concept[].name"` value must be a non-trivial string¹
+- The `"exercises.concept[].name"` value must be a non-blank string¹
 - The `"exercises.concept[].uuid"` key is required
 - The `"exercises.concept[].uuid"` value must be a unique, lowercased v4 UUID string
 - The `"exercises.concept[].deprecated"` key is optional
@@ -105,7 +105,7 @@ The `config.json` file should have the following checks:
 - The `"exercises.practice[].slug"` value must be a kebab-case string²
 - The `"exercises.practice[].slug"` value must be unique in `"exercises.practice[].slug"` and may not exist in `"exercises.concept[].slug"`
 - The `"exercises.practice[].name"` key is required
-- The `"exercises.practice[].name"` value must be a non-trivial string¹
+- The `"exercises.practice[].name"` value must be a non-blank string¹
 - The `"exercises.practice[].uuid"` key is required
 - The `"exercises.practice[].uuid"` value must be a unique, lowercased v4 UUID string
 - The `"exercises.practice[].deprecated"` key is optional
@@ -150,9 +150,9 @@ The `config.json` file should have the following checks:
 - The `"key_features[].icon"` key is required
 - The `"key_features[].icon"` value must be a string that matches one of the pre-defined icon values (TODO: add link to list of icons)
 - The `"key_features[].title"` key is required
-- The `"key_features[].title"` value must be a non-trivial string¹ with length <= 25
+- The `"key_features[].title"` value must be a non-blank string¹ with length <= 25
 - The `"key_features[].content"` key is required
-- The `"key_features[].content"` value must be a non-trivial string¹ with length <= 100
+- The `"key_features[].content"` value must be a non-blank string¹ with length <= 100
 - The `"tags"` key is optional
 - The `"tags"` value must be an array of strings
 - The `"tags"` values must use one of the [pre-defined tag values](https://github.com/exercism/v3-docs/blob/main/anatomy/tracks/config-json.md#tags)
@@ -162,15 +162,15 @@ The `config.json` file should have the following checks:
 - The file must be valid JSON
 - The JSON root must be an object
 - The `"blurb"` key is required
-- The `"blurb"` value must be a non-trivial string¹ with length <= 350
+- The `"blurb"` value must be a non-blank string¹ with length <= 350
 - The `"authors"` key is required
 - The `"authors"` value must be a non-empty array
-- The `"authors"` values must be non-trivial strings¹
+- The `"authors"` values must be non-blank strings¹
 - The `"authors"` values must not have duplicates
 - The `"authors"` values are treated case-insensitively
 - The `"contributors"` key is optional
 - The `"contributors"` value must be an array
-- The `"contributors"` values must be non-trivial strings¹
+- The `"contributors"` values must be non-blank strings¹
 - The `"contributors"` values must not have duplicates
 - The `"contributors"` values are treated case-insensitively
 - Users can only be listed in either the `"authors"` or `"contributors"` array (no overlap)
@@ -219,15 +219,15 @@ The `config.json` file should have the following checks:
 - The file must be valid JSON
 - The JSON root must be an object
 - The `"blurb"` key is required
-- The `"blurb"` value must be a non-trivial string¹ with length <= 350
+- The `"blurb"` value must be a non-blank string¹ with length <= 350
 - The `"authors"` key is optional
 - The `"authors"` value must be an array
-- The `"authors"` values must be non-trivial strings¹
+- The `"authors"` values must be non-blank strings¹
 - The `"authors"` values must not have duplicates
 - The `"authors"` values are treated case-insensitively
 - The `"contributors"` key is optional
 - The `"contributors"` value must be an array
-- The `"contributors"` values must be non-trivial strings¹
+- The `"contributors"` values must be non-blank strings¹
 - The `"contributors"` values must not have duplicates
 - The `"contributors"` values are treated case-insensitively
 - Users can only be listed in either the `"authors"` or `"contributors"` array (no overlap)
@@ -271,7 +271,7 @@ The `config.json` file should have the following checks:
 - The `"[].url"` property is required
 - The `"[].url"` value must be an URL
 - The `"[].description"` property is required
-- The `"[].description"` value must be a non-trivial string¹
+- The `"[].description"` value must be a non-blank string¹
 - The `"[].icon_url"` property is optional
 - The `"[].icon_url"` value must be an URL
 
@@ -280,20 +280,20 @@ The `config.json` file should have the following checks:
 - The file must be valid JSON
 - The JSON root must be an object
 - The `"blurb"` key is required
-- The `"blurb"` value must be a non-trivial string¹ with length <= 350
+- The `"blurb"` value must be a non-blank string¹ with length <= 350
 - The `"authors"` key is required
 - The `"authors"` value must be an array
-- The `"authors"` values must be non-trivial strings¹
+- The `"authors"` values must be non-blank strings¹
 - The `"authors"` values must not have duplicates
 - The `"authors"` values are treated case-insensitively
 - The `"contributors"` key is optional
 - The `"contributors"` value must be an array
-- The `"contributors"` values must be non-trivial strings¹
+- The `"contributors"` values must be non-blank strings¹
 - The `"contributors"` values must not have duplicates
 - The `"contributors"` values are treated case-insensitively
 - Users can only be listed in either the `"authors"` or `"contributors"` array (no overlap)
 
 ## Glossary
 
-1. Non-trivial string: a string that has at least one non-whitespace character.
+1. Non-blank string: a string that contains at least one non-whitespace character.
 2. kebab-case string: a string that contains only characters in the range `[a-z0-9]`, optionally separated by dashes (e.g. "two-fer"). It must match the regular expression: `^[a-z0-9]+(-[a-z0-9]+)*$`

--- a/building/configlet/lint.md
+++ b/building/configlet/lint.md
@@ -47,13 +47,13 @@ The `config.json` file should have the following checks:
 
 - The file must be valid JSON
 - The `"language"` key is required
-- The `"language"` value must be a non-empty, non-blank string
+- The `"language"` value must be a non-trivial string¹
 - The `"slug"` key is required
 - The `"slug"` value must be a non-empty, non-blank, lowercased string using kebab-case
 - The `"active"` key is required
 - The `"active"` value must be a boolean
 - The `"blurb"` key is required
-- The `"blurb"` value must be a non-empty, non-blank string with length <= 400
+- The `"blurb"` value must be a non-trivial string¹ with length <= 400
 - The `"version"` key is required
 - The `"version"` value must be the integer `3`
 - The `"status.concept_exercises"` key is required
@@ -75,7 +75,7 @@ The `config.json` file should have the following checks:
 - The `"exercises.concept[].slug"` value must be a non-empty, non-blank, lowercased string using kebab-case
 - The `"exercises.concept[].slug"` value must be unique in `"exercises.concept[].slug"` and may not exist in `"exercises.practice[].slug"`
 - The `"exercises.concept[].name"` key is required
-- The `"exercises.concept[].name"` value must be a non-empty, non-blank string
+- The `"exercises.concept[].name"` value must be a non-trivial string¹
 - The `"exercises.concept[].uuid"` key is required
 - The `"exercises.concept[].uuid"` value must be a unique, lowercased v4 UUID string
 - The `"exercises.concept[].deprecated"` key is optional
@@ -105,7 +105,7 @@ The `config.json` file should have the following checks:
 - The `"exercises.practice[].slug"` value must be a non-empty, non-blank, lowercased string using kebab-case
 - The `"exercises.practice[].slug"` value must be unique in `"exercises.practice[].slug"` and may not exist in `"exercises.concept[].slug"`
 - The `"exercises.practice[].name"` key is required
-- The `"exercises.practice[].name"` value must be a non-empty, non-blank string
+- The `"exercises.practice[].name"` value must be a non-trivial string¹
 - The `"exercises.practice[].uuid"` key is required
 - The `"exercises.practice[].uuid"` value must be a unique, lowercased v4 UUID string
 - The `"exercises.practice[].deprecated"` key is optional
@@ -150,9 +150,9 @@ The `config.json` file should have the following checks:
 - The `"key_features[].icon"` key is required
 - The `"key_features[].icon"` value must be a string that matches one of the pre-defined icon values (TODO: add link to list of icons)
 - The `"key_features[].title"` key is required
-- The `"key_features[].title"` value must be a non-empty, non-blank string with length <= 25
+- The `"key_features[].title"` value must be a non-trivial string¹ with length <= 25
 - The `"key_features[].content"` key is required
-- The `"key_features[].content"` value must be a non-empty, non-blank string with length <= 100
+- The `"key_features[].content"` value must be a non-trivial string¹ with length <= 100
 - The `"tags"` key is optional
 - The `"tags"` value must be an array of strings
 - The `"tags"` values must use one of the [pre-defined tag values](https://github.com/exercism/v3-docs/blob/main/anatomy/tracks/config-json.md#tags)
@@ -162,15 +162,15 @@ The `config.json` file should have the following checks:
 - The file must be valid JSON
 - The JSON root must be an object
 - The `"blurb"` key is required
-- The `"blurb"` value must be a non-empty, non-blank string with length <= 350
+- The `"blurb"` value must be a non-trivial string¹ with length <= 350
 - The `"authors"` key is required
 - The `"authors"` value must be a non-empty array
-- The `"authors"` values must be non-empty, non-blank strings
+- The `"authors"` values must be non-trivial strings¹
 - The `"authors"` values must not have duplicates
 - The `"authors"` values are treated case-insensitively
 - The `"contributors"` key is optional
 - The `"contributors"` value must be an array
-- The `"contributors"` values must be non-empty, non-blank strings
+- The `"contributors"` values must be non-trivial strings¹
 - The `"contributors"` values must not have duplicates
 - The `"contributors"` values are treated case-insensitively
 - Users can only be listed in either the `"authors"` or `"contributors"` array (no overlap)
@@ -219,15 +219,15 @@ The `config.json` file should have the following checks:
 - The file must be valid JSON
 - The JSON root must be an object
 - The `"blurb"` key is required
-- The `"blurb"` value must be a non-empty, non-blank string with length <= 350
+- The `"blurb"` value must be a non-trivial string¹ with length <= 350
 - The `"authors"` key is optional
 - The `"authors"` value must be an array
-- The `"authors"` values must be non-empty, non-blank strings
+- The `"authors"` values must be non-trivial strings¹
 - The `"authors"` values must not have duplicates
 - The `"authors"` values are treated case-insensitively
 - The `"contributors"` key is optional
 - The `"contributors"` value must be an array
-- The `"contributors"` values must be non-empty, non-blank strings
+- The `"contributors"` values must be non-trivial strings¹
 - The `"contributors"` values must not have duplicates
 - The `"contributors"` values are treated case-insensitively
 - Users can only be listed in either the `"authors"` or `"contributors"` array (no overlap)
@@ -271,7 +271,7 @@ The `config.json` file should have the following checks:
 - The `"[].url"` property is required
 - The `"[].url"` value must be an URL
 - The `"[].description"` property is required
-- The `"[].description"` value must be a non-empty, non-blank string
+- The `"[].description"` value must be a non-trivial string¹
 - The `"[].icon_url"` property is optional
 - The `"[].icon_url"` value must be an URL
 
@@ -280,19 +280,20 @@ The `config.json` file should have the following checks:
 - The file must be valid JSON
 - The JSON root must be an object
 - The `"blurb"` key is required
-- The `"blurb"` value must be a non-empty, non-blank string with length <= 350
+- The `"blurb"` value must be a non-trivial string¹ with length <= 350
 - The `"authors"` key is required
 - The `"authors"` value must be an array
-- The `"authors"` values must be non-empty, non-blank strings
+- The `"authors"` values must be non-trivial strings¹
 - The `"authors"` values must not have duplicates
 - The `"authors"` values are treated case-insensitively
 - The `"contributors"` key is optional
 - The `"contributors"` value must be an array
-- The `"contributors"` values must be non-empty, non-blank strings
+- The `"contributors"` values must be non-trivial strings¹
 - The `"contributors"` values must not have duplicates
 - The `"contributors"` values are treated case-insensitively
 - Users can only be listed in either the `"authors"` or `"contributors"` array (no overlap)
 
 ## Glossary
 
+1. Non-trivial string: a string that has at least one non-whitespace character.
 - _kebab_case_: strings containing only characters in the range `[a-z0-9]` optionally separated by dashes (e.g. "two-fer"). In regular expression format: `^[a-z0-9]+(-[a-z0-9]+)*$`


### PR DESCRIPTION
I don't think this PR is a *strict* improvement, but I think overall it makes the spec more readable. The reader of 
> non-empty, non-blank string
> non-empty, non-blank, lowercased string using kebab-case

will no longer ask questions like:
- "do we allow a whitespace-only string somewhere?"
- "is there a kebab-case string somewhere that's allowed to contain uppercase?"

I don't love the phrase "non-trivial string". Can we think of something better?