### PR TITLE
Fix link to Dockerfile best practices

### DIFF
--- a/building/tooling/docker.md
+++ b/building/tooling/docker.md
@@ -8,7 +8,7 @@ It should live at the root directory of your repository and should be called `Do
 The Dockerfile should create the minimal image needed for the tooling to function correctly and speedily.
 
 The Dockerfile should produce an image with as a small a size as possible while maximising (and prioritising) perfomance.
-Applying the official [Dockerfile best practices](https://docs.docker.com/develop/develop-images/Dockerfile_best-practices/) can help to create a minimal image.
+Applying the official [Dockerfile best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) can help to create a minimal image.
 
 ## Execution
 


### PR DESCRIPTION
The previous link doesn't work. It displays:
> Sorry, we can't find that page

> There might be a mistake in the URL or you might’ve clicked a link
> to content that no longer exists.

---

The `exercism/docs` repo only linked to this page in one place.

With this PR:
```
$ git grep --heading --break 'docker.com'
building/tooling/docker.md
11:Applying the official [Dockerfile best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/) can help to create a minimal image.
58:Memory [should be specified](https://docs.docker.com/config/containers/resource_constraints/#limit-a-containers-access-to-memory) using the number with suffix of b, k, m, g, to indicate bytes, kilobytes, megabytes, or gigabytes.
```