### PR TITLE
Add average run time

### DIFF
--- a/building/configlet/lint.md
+++ b/building/configlet/lint.md
@@ -72,6 +72,8 @@ The `config.json` file should have the following checks:
 - The `"online_editor.ace_editor_language"` value must be a non-blank string¹
 - The `"online_editor.highlightjs_language"` key is required
 - The `"online_editor.highlightjs_language"` value must be a non-blank string¹
+- The `"test_runner.average_run_time"` key is required if `status.test_runner` is equal to `true`
+- The `"test_runner.average_run_time"` value must be a floating-point number > 0 with one decimal point of precision
 - The `"exercises"` key is required
 - The `"exercises.concept"` key is required
 - The `"exercises.concept"` value must be an array

--- a/building/tracks/config-json.md
+++ b/building/tracks/config-json.md
@@ -28,7 +28,7 @@ The following top-level properties contain general track metadata:
   - `exemplar`: exemplar implementation file(s) pattern (optional)
   - `editor`: additional read-only editor file(s) patterns (optional)
 - `test_runner`: an object describing the track's test runner (if any): (required if `status.test_runner` is `true`)
-  - `average_run_time`: a `float` value for the number of seconds the test runner takes on average to run, rounded to one decimal point precision (e.g. `1.8`) (required if `status.test_runner` is `true`)
+  - `average_run_time`: a `number` value for the number of seconds the test runner takes on average to run, rounded to one decimal point precision (e.g. `1.8`) (required if `status.test_runner` is `true`)
 
 ### Files
 

--- a/building/tracks/config-json.md
+++ b/building/tracks/config-json.md
@@ -27,6 +27,8 @@ The following top-level properties contain general track metadata:
   - `example`: example implementation file(s) pattern (optional
   - `exemplar`: exemplar implementation file(s) pattern (optional)
   - `editor`: additional read-only editor file(s) patterns (optional)
+- `test_runner`: an object describing the track's test runner (if any): (required if `status.test_runner` is `true`)
+  - `average_run_time`: a `float` value for the number of seconds the test runner takes on average to run, rounded to one decimal point precision (e.g. `1.8`) (required if `status.test_runner` is `true`)
 
 ### Files
 


### PR DESCRIPTION
Add `test_runner.average_run_time` field to a track's `config.json` file. This allows the website to display a progress bar indicator.
