### PR TITLE
Update concept exercise icon list link

### DIFF
--- a/building/tracks/concept-exercises.md
+++ b/building/tracks/concept-exercises.md
@@ -294,7 +294,7 @@ This file contains meta information on the exercise:
 - `blurb`: A short description of this exercise. Its length must be <= 350. Markdown is _not_ supported (required)
 - `source`: The source this exercise is based on (optional)
 - `source_url`: The URL of the source this exercise is based on (optional)
-- `icon`: The slug of the icon (see [the full list of icons](https://github.com/exercism/website-icons/tree/main/v3-exercises)). If not specified, the exercise's slug will be used (optional)
+- `icon`: The slug of the icon (see [the full list of icons](https://github.com/exercism/website-icons/tree/main/exercises)). If not specified, the exercise's slug will be used (optional)
 
 If someone is both an author _and_ a contributor, only list that person as an author.
 


### PR DESCRIPTION
The icons were moved in this commit: https://github.com/exercism/website-icons/commit/85fa0641e38de41494a9ada6a177e296c06dcd0a