### PR TITLE
Fix inconsistent `blurb` length

### DIFF
--- a/building/tracks/config-json.md
+++ b/building/tracks/config-json.md
@@ -9,7 +9,7 @@ The following top-level properties contain general track metadata:
 - `language`: the track's language (e.g. `"C#"`). Its length must be <= 255. (required)
 - `slug`: the track's language as a lowercased, kebab-case string (e.g. `"csharp"`). Its length must be <= 255. (required)
 - `active`: a `boolean` value indicating if the track is active (i.e. students can join the track on the website) (required)
-- `blurb`: a short description of the language. Its length must be <= 255. (required)
+- `blurb`: a short description of the language. Its length must be <= 400. (required)
 - `version`: the version of the `config.json` file (currently fixed to `3`) (required)
 - `ace_editor_language`: the language identifier for the Ace editor (see the [full list of identifiers](https://github.com/ajaxorg/ace/tree/master/lib/ace/mode)) (required)
 - `highlightjs_language`: the language identifier for Highlight.js (see the [full list of identifiers](https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md)) (required)


### PR DESCRIPTION
This PR is a follow-up of https://github.com/exercism/docs/pull/133.

In [building/configlet/lint.md](https://github.com/exercism/docs/blob/2f2134f/building/configlet/lint.md) it says:
> - The `"blurb"` value must be a non-blank string¹ with length <= 400

Do we want to change this in `building/tracks/config-json` or in `lint.md`?