### PR TITLE
remove `online_editor.ace_editor_language` property

### DIFF
--- a/building/configlet/lint.md
+++ b/building/configlet/lint.md
@@ -68,8 +68,6 @@ The `config.json` file should have the following checks:
 - The `"online_editor.indent_style"` value must be the string `space` or `tab`
 - The `"online_editor.indent_size"` key is required
 - The `"online_editor.indent_size"` value must be an integer >= 0 and <= 8
-- The `"online_editor.ace_editor_language"` key is required
-- The `"online_editor.ace_editor_language"` value must be a non-blank string¹
 - The `"online_editor.highlightjs_language"` key is required
 - The `"online_editor.highlightjs_language"` value must be a non-blank string¹
 - The `"test_runner.average_run_time"` key is required if `status.test_runner` is equal to `true`

--- a/building/tracks/config-json.md
+++ b/building/tracks/config-json.md
@@ -11,7 +11,6 @@ The following top-level properties contain general track metadata:
 - `active`: a `boolean` value indicating if the track is active (i.e. students can join the track on the website) (required)
 - `blurb`: a short description of the language. Its length must be <= 400. (required)
 - `version`: the version of the `config.json` file (currently fixed to `3`) (required)
-- `ace_editor_language`: the language identifier for the Ace editor (see the [full list of identifiers](https://github.com/ajaxorg/ace/tree/master/lib/ace/mode)) (required)
 - `highlightjs_language`: the language identifier for Highlight.js (see the [full list of identifiers](https://github.com/highlightjs/highlight.js/blob/main/SUPPORTED_LANGUAGES.md)) (required)
 - `online_editor`: an object describing settings used for the online editor: (required)
   - `indent_style`: either `"space"` or `"tab"` (required)
@@ -52,7 +51,6 @@ Support will be added to [configlet](./README.md) to use these pattern to popula
   "active": true,
   "blurb": "C# is a modern, object-oriented language with lots of great features, such as type-inference and async/await. The tooling is excellent, and there is extensive, well-written documentation.",
   "version": 3,
-  "ace_editor_language": "csharp",
   "highlightjs_language": "csharp",
   "online_editor": {
     "indent_style": "space",


### PR DESCRIPTION
With the switch to CodeMirror as the online editor library, the
`online_editor.ace_editor_language` key is now obsolete. This commit
removes it from the docs.

---

I've checked that, with this PR, `git grep 'editor_language'` produces no output.