### PR TITLE
Require the `tags` property to exist

### DIFF
--- a/building/configlet/lint.md
+++ b/building/configlet/lint.md
@@ -161,7 +161,7 @@ The `config.json` file should have the following checks:
 - The `"key_features[].title"` value must be a non-blank string¹ with length <= 25
 - The `"key_features[].content"` key is required
 - The `"key_features[].content"` value must be a non-blank string¹ with length <= 100
-- The `"tags"` key is optional
+- The `"tags"` key is required
 - The `"tags"` value must be an array of strings
 - The `"tags"` values must not have duplicates
 - The `"tags"` values must use one of the [pre-defined tag values](../tracks/config-json.md#tags)


### PR DESCRIPTION
`configlet lint` always required `tags` to exist. I think we wanted to encourage tracks to add tags.

I'm making this PR just in case we want to change the spec, rather than configlet. Feel free to close and say "we really do want `tags` to be optional - change configlet, but maybe wait a little while first".

According to @ErikSchierboom, the following tracks don't have the `tags` property set in their `config.json`:
- cfml
- clojure
- clojurescript
- coffeescript
- crystal
- d
- emacs-lisp
- haskell
- kotlin
- lfe
- mips
- objective-c
- ocaml
- perl5
- plsql
- prolog
- racket
- raku
- ruby
- scala
- scheme
- sml
- swift
- vimscript
- x86-64-assembly
