### PR TITLE
Try to clarify label `x:type/coding` better

### DIFF
--- a/product/tasks.md
+++ b/product/tasks.md
@@ -71,13 +71,13 @@ The `x:size/<value>` labels describe the expected amount of work for a contribut
 
 The `x:type/<value>` labels describe the type of work the contributor will be engaged in.
 
-| Tag              | Description                                                                                                                                                                                                                     |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `x:type/ci`      | Work on Continuous Integration (e.g. GitHub Actions workflows)                                                                                                                                                                  |
-| `x:type/coding`  | Work involving writing code that is not part of the student-facing content. This is normally tasks associated with production-tooling (e.g. test runners), internal-tooling (generators), or libraries that Exercism maintains. |
-| `x:type/content` | Work on content (e.g. exercises, concepts)                                                                                                                                                                                      |
-| `x:type/docker`  | Work on Dockerfiles                                                                                                                                                                                                             |
-| `x:type/docs`    | Work on Documentation                                                                                                                                                                                                           |
+| Tag              | Description                                                                                                                                                                                                    |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `x:type/ci`      | Work on Continuous Integration (e.g. GitHub Actions workflows)                                                                                                                                                 |
+| `x:type/coding`  | Write code that is not part of the student-facing content. This is normally tasks associated with production-tooling (e.g. test runners), internal-tooling (generators), or libraries that Exercism maintains. |
+| `x:type/content` | Work on content (e.g. exercises, concepts)                                                                                                                                                                     |
+| `x:type/docker`  | Work on Dockerfiles                                                                                                                                                                                            |
+| `x:type/docs`    | Work on Documentation                                                                                                                                                                                          |
 
 ## Claimed vs unclaimed tags
 

--- a/product/tasks.md
+++ b/product/tasks.md
@@ -71,13 +71,13 @@ The `x:size/<value>` labels describe the expected amount of work for a contribut
 
 The `x:type/<value>` labels describe the type of work the contributor will be engaged in.
 
-| Tag              | Description                                                    |
-| ---------------- | -------------------------------------------------------------- |
-| `x:type/ci`      | Work on Continuous Integration (e.g. GitHub Actions workflows) |
-| `x:type/coding`  | Work on code that will run in production                       |
-| `x:type/content` | Work on content (e.g. exercises, concepts)                     |
-| `x:type/docker`  | Work on Dockerfiles                                            |
-| `x:type/docs`    | Work on Documentation                                          |
+| Tag              | Description                                                       |
+| ---------------- | ----------------------------------------------------------------- |
+| `x:type/ci`      | Work on Continuous Integration (e.g. GitHub Actions workflows)    |
+| `x:type/coding`  | Work on code that is not part of the content (e.g. track tooling) |
+| `x:type/content` | Work on content (e.g. exercises, concepts)                        |
+| `x:type/docker`  | Work on Dockerfiles                                               |
+| `x:type/docs`    | Work on Documentation                                             |
 
 ## Claimed vs unclaimed tags
 

--- a/product/tasks.md
+++ b/product/tasks.md
@@ -71,13 +71,13 @@ The `x:size/<value>` labels describe the expected amount of work for a contribut
 
 The `x:type/<value>` labels describe the type of work the contributor will be engaged in.
 
-| Tag              | Description                                                       |
-| ---------------- | ----------------------------------------------------------------- |
-| `x:type/ci`      | Work on Continuous Integration (e.g. GitHub Actions workflows)    |
-| `x:type/coding`  | Work on code that is not part of the content (e.g. track tooling) |
-| `x:type/content` | Work on content (e.g. exercises, concepts)                        |
-| `x:type/docker`  | Work on Dockerfiles                                               |
-| `x:type/docs`    | Work on Documentation                                             |
+| Tag              | Description                                                                                                                                                                                                                     |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `x:type/ci`      | Work on Continuous Integration (e.g. GitHub Actions workflows)                                                                                                                                                                  |
+| `x:type/coding`  | Work involving writing code that is not part of the student-facing content. This is normally tasks associated with production-tooling (e.g. test runners), internal-tooling (generators), or libraries that Exercism maintains. |
+| `x:type/content` | Work on content (e.g. exercises, concepts)                                                                                                                                                                                      |
+| `x:type/docker`  | Work on Dockerfiles                                                                                                                                                                                                             |
+| `x:type/docs`    | Work on Documentation                                                                                                                                                                                                           |
 
 ## Claimed vs unclaimed tags
 


### PR DESCRIPTION
I was confused that `x:type/coding` is being used to label issues for a test generator because test generators do not run in production. @iHiD answer was:

> type/coding means that you're doing actual work coding. However, because it was argued that writing exercises is also coding (as you write tests), we tried to distinguish specifically writing code that is used by Exercism, not by students as part of their learning.
>
> Generators fall into that "coding" bucket of things that I want the label to mean, but I entirely understand that its confusing as they're not "in production" as you say.


This PR is my proposal for how to explain this label better.