### PR TITLE
Fix example track `config.json` file

### DIFF
--- a/building/tracks/config-json.md
+++ b/building/tracks/config-json.md
@@ -67,6 +67,9 @@ Support will be added to [configlet](./README.md) to use these pattern to popula
     "test": ["%{pascal_slug}Tests.cs"],
     "example": [".meta/Example.cs"],
     "exemplar": [".meta/Exemplar.cs"]
+  },
+  "test_runner": {
+    "average_run_time": 2.3
   }
 }
 ```
@@ -364,7 +367,11 @@ This is an example of what a valid `config.json` file can look like:
   },
   "online_editor": {
     "indent_style": "space",
-    "indent_size": 4
+    "indent_size": 4,
+    "highlightjs_language": "csharp"
+  },
+  "test_runner": {
+    "average_run_time": 2.3
   },
   "exercises": {
     "concept": [


### PR DESCRIPTION
The example `config.json` file at the bottom is introduced with
> "This is an example of what a valid `config.json` file can look like"

But the example JSON file was not actually valid, as it was missing:
- The `online_editor.highlightjs_language` property
- The `test_runner.average_run_time` property, which is required because
  `status.test_runner` is `true` in the example

This commit also adds the `test_runner.average_run_time` property to
the partial example at the top of the file, where `status.test_runner`
is similarly `true`.