### PR TITLE
Add `files` linting rules for track-level `config.json`

### DIFF
--- a/building/configlet/lint.md
+++ b/building/configlet/lint.md
@@ -70,6 +70,29 @@ The `config.json` file should have the following checks:
 - The `"online_editor.indent_size"` value must be an integer >= 0 and <= 8
 - The `"online_editor.highlightjs_language"` key is required
 - The `"online_editor.highlightjs_language"` value must be a non-blank string¹
+- The `"files"` key is optional
+- The `"files"` value must be an object
+- The `"files.solution`" key is optional
+- The `"files.solution`" value must be an array
+- The `"files.solution`" values must be valid patterns⁴
+- The `"files.solution`" values must not have duplicates
+- The `"files.test`" key is optional
+- The `"files.test`" value must be an array
+- The `"files.test`" values must be valid patterns⁴
+- The `"files.test`" values must not have duplicates
+- The `"files.example`" key is optional
+- The `"files.example`" value must be an array
+- The `"files.example`" values must be valid patterns⁴
+- The `"files.example`" values must not have duplicates
+- The `"files.exemplar`" key is optional
+- The `"files.exemplar`" value must be an array
+- The `"files.exemplar`" values must be valid patterns⁴
+- The `"files.exemplar`" values must not have duplicates
+- The `"files.editor`" key is optional
+- The `"files.editor`" value must be an array
+- The `"files.editor`" values must be valid patterns⁴
+- The `"files.editor`" values must not have duplicates
+- Patterns can only be listed in either the `"files.solution"`, `"files.test"`, `"files.example`, `"files.exemplar` or `"files.editor` array (no overlap)
 - The `"test_runner.average_run_time"` key is required if `status.test_runner` is equal to `true`
 - The `"test_runner.average_run_time"` value must be a floating-point number > 0 with one decimal point of precision
 - The `"exercises"` key is required
@@ -330,3 +353,8 @@ The `config.json` file should have the following checks:
    > - Lowercase prepositions, regardless of length, except when they are stressed, are used adverbially or adjectivally, or are used as conjunctions.
    > - Lowercase the words _to_ and _as_.
    > - Lowercase the second part of Latin species names.
+4. Valid `files` pattern: A non-blank string¹ that specifies a location of a file used in an exercise, relative to the exercise's directory. A pattern may use one of the following placeholders:
+- `%{kebab_slug}`: the `kebab-case` exercise slug (e.g. `bit-manipulation`)
+- `%{snake_slug}`: the `snake_case` exercise slug (e.g. `bit_manipulation`)
+- `%{camel_slug}`: the `camelCase` exercise slug (e.g. `bitManipulation`)
+- `%{pascal_slug}`: the `PascalCase` exercise slug (e.g. `BitManipulation`)


### PR DESCRIPTION
These properties were described in `building/tracks/config-json.md`, but
were missing from `building/configlet/lint.md`.

---

Do we want this?

It's true that the track-level `files` property will only used by `configlet sync`. But it feels like `configlet lint` should complain about a problem in this property, otherwise a user might:
1. Clone a track
2. Run `configlet sync`
3. See an error message due to an invalid pattern in the `files` property  

The alternative attempt to catch a problem with `files` at CI-time doesn't work: we could run `configlet sync` during CI on every track, and make it exit non-zero for a problem with `files`. But `configlet sync` will already produce a non-zero exit code if there's something unsynced, so we can't easily distinguish a problem with `files`.