### PR TITLE
Fix more configlet links

### DIFF
--- a/building/configlet/README.md
+++ b/building/configlet/README.md
@@ -4,28 +4,28 @@
 
 ## Linting
 
-The primary function of configlet is to do _linting_: checking if a track's configuration files are properly structured - both syntactically and semantically. Misconfigured tracks may not sync correctly, may look wrong on the website, or may present a suboptimal user experience, so configlet's guards play an important part in maintaining the integrity of Exercism. The full list of rules that are checked by the linter can be found [here](./lint).
+The primary function of configlet is to do _linting_: checking if a track's configuration files are properly structured - both syntactically and semantically. Misconfigured tracks may not sync correctly, may look wrong on the website, or may present a suboptimal user experience, so configlet's guards play an important part in maintaining the integrity of Exercism. The full list of rules that are checked by the linter can be found [here](./configlet/lint).
 
 ## Generating documents
 
 The secondary function of configlet is to generate documents. There are two types of documents that configlet can generate:
 
-1. A Concept Exercise's [`introduction.md` file](./generating-documents#document-concept-exercises-introductionmd-file).
-1. A Practice Exercise's [`instructions.md` file](./generating-documents#document-practice-exercises-instructionsmd-file).
+1. A Concept Exercise's [`introduction.md` file](./configlet/generating-documents#document-concept-exercises-introductionmd-file).
+1. A Practice Exercise's [`instructions.md` file](./configlet/generating-documents#document-practice-exercises-instructionsmd-file).
 
-How these documents are generated can be found [here](./generating-documents).
+How these documents are generated can be found [here](./configlet/generating-documents).
 
 ## Syncing test data
 
 The tertiary function of configlet is to sync test data. Each implemented [Practice Exercise](./tracks/practice-exercises) for which test data exists in the [problem-specifications repo](https://github.com/exercism/problem-specifications) _must_ contain a `.meta/tests.toml` file. The goal of this file is to keep track of which tests are implemented by the exercise. Tests in this file are identified by their UUID and each test has a boolean value that indicates if it is implemented by that exercise.
 
-How to sync the contents of the `.meta/tests.toml` can be found [here](./sync)
+How to sync the contents of the `.meta/tests.toml` can be found [here](./configlet/sync)
 
 ## Generating UUIDs
 
 Exercises, tracks and concepts are identified by a UUID.
 
-How to generate UUIDs can be found [here](./uuid).
+How to generate UUIDs can be found [here](./configlet/uuid).
 
 ## Usage
 


### PR DESCRIPTION
I was expecting these links to work after #159.

But if you go to https://exercism.lol/docs/building/configlet, it contains e.g.:
> How these documents are generated can be found [here](https://exercism.lol/docs/building/generating-documents)

where the links go to e.g.
https://exercism.lol/docs/building/generating-documents (broken)
rather than
https://exercism.lol/docs/building/configlet/generating-documents

So I've tried to fix this by adding `configlet/`. Is this what we want?

This feels weird to me because `README.md` is in the `building/configlet` directory - I was expecting `./` in this file to be relative to the `building/configlet` directory, not the `building` directory. 

When I understand better I'll also push a commit to this PR for some broken links in `generating-documents`.