### PR TITLE
Clarify issue `x:size` and awarded reputation

### DIFF
--- a/product/reputation.md
+++ b/product/reputation.md
@@ -58,6 +58,8 @@ For each merged pull request that was opened by the user, `12` reputation is awa
 
   If more than one label is specified, the label with the highest reputation value determines the awarded reputation.
 
+  Note that an `x:size` label on an **issue** never affects the awarded reputation - even if a merged pull request lacks an `x:size` label, and closes an issue that has one.
+
 ### 5. Reviewing pull requests
 
 For each merged or closed pull request reviewed by the user, `5` reputation is awarded.


### PR DESCRIPTION
This makes it more explicit that only the PR `x:size` label matters for
determining awarded reputation.

---

This PR just follows up on some questions that I asked Erik in https://github.com/exercism/org-wide-files/pull/25#issuecomment-873158161