### PR TITLE
Update how_to_give_great_feedback.md

### DIFF
--- a/mentoring/how_to_give_great_feedback.md
+++ b/mentoring/how_to_give_great_feedback.md
@@ -1,11 +1,11 @@
 # How to give great feedback
 
 At this stage you should have chosen a solution to mentor.
-If you've not, work your way through [Choosing a solution to mentor](./choosing-a-solution) first, then come back here.
+If you haven't, work your way through [Choosing a solution to mentor](./choosing-a-solution) first, then come back here.
 
 ## Your first feedback
 
-You're now about to give your first feedback to a student.
+You're about to give your first feedback to a student.
 This can be exciting but also pretty daunting.
 A lot of (the best!) mentors suffer from [Impostor Syndrome](https://en.wikipedia.org/wiki/Impostor_syndrome) at this stage, and give up before they start.
 If you feel like that, it's totally understandable, but also almost always unnecessary.
@@ -31,11 +31,11 @@ It's really important that you as the mentor read that and try and address it in
 However, one of the key values of mentoring on Exercism is that mentors can help students discover ideas they had no idea about.
 So you might look at a student's solution, read their comment which asks if there are any tweaks they could make, and think "Wow - you really don't have a grasp on this exercise at all".
 It might be that they've totally missed the point of the exercise.
-In your time as a mentor, you'll see some incredibly "overfit" solutons where students make the tests pass but totally miss the point of the challenge.
+In your time as a mentor, you'll see some incredibly "overfit" solutions where students make the tests pass but totally miss the point of the challenge.
 Or see incredibly complex solutions that can be rewritten in a couple of lines of code.
 
 Your job as a mentor is to help take the student forward **from where they start**.
-What's the biggest thing you could do to help unlock an idea or unblock your thinking?
+What's the biggest thing you could do to help unlock an idea or unblock their thinking?
 You'll find that if you can explain an idea to a student and set a lightbulb off in their head, it'll be an incredibly rewarding discussion.
 
 ## Don't just give the solution away
@@ -49,7 +49,7 @@ Different mentors have different approaches to whether they give "hints" or "exp
 As a general rule, aim for somewhere between the two.
 Ensure that you tell the student enough that they can understand what they should try, but try not to just give them the answer and tell them why it works.
 
-For example, let's imagine you see an `if` statement in Ruby that would be much more nicely written using the [ternary operator](https://en.wikipedia.org/wiki/%3F:):
+For example, imagine you see an `if` statement in Ruby that would be much more nicely written using the [ternary operator](https://en.wikipedia.org/wiki/%3F:):
 
 ```
 # Student's code
@@ -63,7 +63,7 @@ end
 b = a ? 1 : 2
 ```
 
-You could just say "Write `b = a ? 1 : 2` instead of the `if` statement on L10.
+You could just say "Write `b = a ? 1 : 2` instead of the `if` statement on L10."
 But that wouldn't be helping a student understand the why or have a lightbulb moment of their own.
 
 Instead it would be much better to introduce the idea of a ternary, and pose the student a challenge.
@@ -83,6 +83,6 @@ As you gain experience mentoring, you will get a feel for the different ways stu
 
 ## Unsure of something? Chat to other mentors?
 
-One of the best things about being an Exercism mentor, is the community of other mentors you can learn from.
-If you've got a question about a solution, or just want to bounce ideas with other mentors, jump into our [Slack Room]() and ask away!
+One of the best things about being an Exercism mentor is the community of other mentors you can learn from.
+If you've got a question about a solution, or just want to bounce ideas with other mentors, jump into our [Slack Workspace]() and ask away!
 You'll probably find people you can help there too 🙂


### PR DESCRIPTION
Feedback that doesn't fit the suggestions/PR format too well:

L10-13: I'm not sure using "almost always" etc works well in the context of imposter syndrome. This could just add to it because there's a chance one's concerns fall under the "almost". I think this is one place where stronger wording may actually be better.

L21: Don't we know this due to the new information what one wants from Exercism/a track? I might be mixing things up.

L41ff: On some tracks, the mentor notes contain a number of annotated example/expert solutions. Sharing these once an exercise has been solved should be encouraged. I think that could be made clearer here, but I'm not quite sure where it fits in.

L78: To some people, this can be incredibly frustrating and they'd rather want everything at once. They may state so in their preferences, I guess, but it's worth pointing out that's also a possibility. I personally hate it to have constantly shifting goal posts rather than hearing everything that's wrong at once (unless fixing it in one step isn't feasible, but even then it should be mentioned ahead of time). I'd expect a mentor to respect that if I state so. Currently the doc makes it sound too much like a fixed rule to me.

L82: This sentence feels weird. The first half is about getting a feel for the students, the 2nd half is about developing your own style, ignoring the personality or preferences of the students. Not sure how to phrase it better, perhaps split it up in two sentences?