### PR TITLE
Clarify `status` and `message` in test runner spec

### DIFF
--- a/building/tooling/test-runners/interface.md
+++ b/building/tooling/test-runners/interface.md
@@ -49,7 +49,7 @@ The following overall statuses are valid:
 
 > version: 1, 2, 3
 
-Where the status is `error` (no test was executed cleanly), the top level `message` key should be provided. It should provide the occurring error to the user. As it is the only piece of information a user will receive on how to debug their issue, it must be as clear as possible. For example, in Ruby, in the case of a syntax error, we provide the error and stack trace. In compiled languages, the compilation error should be provided. The top level `message` value is not limited in length.
+Where the status is `error` (no test was executed correctly), the top level `message` key should be provided. It should provide the occurring error to the user. As it is the only piece of information a user will receive on how to debug their issue, it must be as clear as possible. For example, in Ruby, in the case of a syntax error, we provide the error and stack trace. In compiled languages, the compilation error should be provided. The top level `message` value is not limited in length.
 
 When the status is not `error`, either set the value to `null` or omit the key entirely.
 

--- a/building/tooling/test-runners/interface.md
+++ b/building/tooling/test-runners/interface.md
@@ -41,7 +41,7 @@ The following overall statuses are valid:
 
 - `pass`: All tests passed
 - `fail`: At least one test has the status `fail` or `error`
-- `error`: To be used when the tests did not run correctly (e.g. a compile error, a syntax error)
+- `error`: No test was executed correctly (this usually means e.g. a compile error, or a syntax error)
 
 #### Message
 
@@ -49,7 +49,7 @@ The following overall statuses are valid:
 
 > version: 1, 2, 3
 
-Where the status is `error` (the tests fail to execute cleanly), the top level `message` key should be provided. It should provide the occurring error to the user. As it is the only piece of information a user will receive on how to debug their issue, it must be as clear as possible. For example, in Ruby, in the case of a syntax error, we provide the error and stack trace. In compiled languages, the compilation error should be provided. The top level `message` value is not limited in length.
+Where the status is `error` (no test was executed cleanly), the top level `message` key should be provided. It should provide the occurring error to the user. As it is the only piece of information a user will receive on how to debug their issue, it must be as clear as possible. For example, in Ruby, in the case of a syntax error, we provide the error and stack trace. In compiled languages, the compilation error should be provided. The top level `message` value is not limited in length.
 
 When the status is not `error`, either set the value to `null` or omit the key entirely.
 

--- a/building/tooling/test-runners/interface.md
+++ b/building/tooling/test-runners/interface.md
@@ -119,7 +119,7 @@ The following per-test statuses are valid:
 
 - `pass`: The test passed
 - `fail`: The test failed
-- `error`: The test errored
+- `error`: The test errored - that is, it did not return a value
 
 #### Message
 

--- a/building/tooling/test-runners/interface.md
+++ b/building/tooling/test-runners/interface.md
@@ -127,7 +127,7 @@ The following per-test statuses are valid:
 
 > version: 2, 3
 
-The per-test `message` key is used to return the results of a test with a `status` of `fail` or `error`. It should be as human-readable as possible. Whatever is written here will be displayed to the student when their test does not pass. If there is no test failure or error message, either set the value to `null` or omit the key entirely. It is also permissible to output test suite output here. The `message` value is not limited in length.
+The per-test `message` key is used to return the results of a test with a `status` of `fail` or `error`. It should be as human-readable as possible. Whatever is written here will be displayed to the student when their test does not pass. If there is no test failure message or error message, either set the value to `null` or omit the key entirely. It is also permissible to output test suite output here. The `message` value is not limited in length.
 
 #### Output
 

--- a/building/tooling/test-runners/interface.md
+++ b/building/tooling/test-runners/interface.md
@@ -127,7 +127,7 @@ The following per-test statuses are valid:
 
 > version: 2, 3
 
-The per-test `message` key is used to return the results of a failed test. It should be as human-readable as possible. Whatever is written here will be displayed to the student when their test fails. If there is no error message, either set the value to `null` or omit the key entirely. It is also permissible to output test suite output here. The `message` value is not limited in length.
+The per-test `message` key is used to return the results of a test with a `status` of `fail` or `error`. It should be as human-readable as possible. Whatever is written here will be displayed to the student when their test does not pass. If there is no informational message, either set the value to `null` or omit the key entirely. It is also permissible to output test suite output here. The `message` value is not limited in length.
 
 #### Output
 

--- a/building/tooling/test-runners/interface.md
+++ b/building/tooling/test-runners/interface.md
@@ -127,7 +127,7 @@ The following per-test statuses are valid:
 
 > version: 2, 3
 
-The per-test `message` key is used to return the results of a test with a `status` of `fail` or `error`. It should be as human-readable as possible. Whatever is written here will be displayed to the student when their test does not pass. If there is no informational message, either set the value to `null` or omit the key entirely. It is also permissible to output test suite output here. The `message` value is not limited in length.
+The per-test `message` key is used to return the results of a test with a `status` of `fail` or `error`. It should be as human-readable as possible. Whatever is written here will be displayed to the student when their test does not pass. If there is no test failure or error message, either set the value to `null` or omit the key entirely. It is also permissible to output test suite output here. The `message` value is not limited in length.
 
 #### Output
 

--- a/building/tooling/test-runners/interface.md
+++ b/building/tooling/test-runners/interface.md
@@ -40,7 +40,7 @@ The version of the spec that this file adheres to:
 The following overall statuses are valid:
 
 - `pass`: All tests passed
-- `fail`: At least one test failed
+- `fail`: At least one test has the status `fail` or `error`
 - `error`: To be used when the tests did not run correctly (e.g. a compile error, a syntax error)
 
 #### Message


### PR DESCRIPTION
Reproducing the commit messages:


#### Clarify top-level `fail` in test runner spec

Consider the situation of:
- The user submits a solution in a compiled language
- The user's solution compiles without error
- The first test passes, but the next test "produces an error" (for
  example, it raises an exception).

In this case, the correct top-level status is `fail`, with one
test-level status of `pass`, and one test-level status of `error`. But
the previous wording could imply that a top-level status of `fail`
is only correct if at least one test has the status `fail`.


#### Clarify per-test `message` in test runner spec

The previous wording could imply that a per-test `message` property
can only be present when the test `status` is `fail`.


#### Clarify top-level `error` in test runner spec

To me, the previous wording implied that a top-level `status` of `error`
is valid when at least one test "errors". But actually, if at least one
test was "executed", the top-level status should be `pass` or `fail`.

#### Try to clarify test-level `error` in test runner spec

(Difficult).

---

I'm making this PR because in https://github.com/exercism/nim-test-runner/pull/87#issuecomment-875501804 it was unclear to me what the expected `results.json` is when a test errors. 

I wanted to incorporate Erik's clarification for a top-level `status`:
> If any of the tests _were_ executed, the `status` property should be `null` or omitted.

and for a test-level `status`:
> In this case the key thing is that no result is returned, so you can't know if it would be a pass or fail, so `error` is appropriate here.

because I think the current docs don't convey this.

I think `fail` vs `error` could be clearer elsewhere in `interface.md` too (I'd appreciate if someone could read through the full `interface.md` contents with this PR and help out), but I'll set this PR as non-draft in case we prefer to follow-up later.