### PR TITLE
Remove property named `deprecated` from linting spec

### DIFF
--- a/building/configlet/lint.md
+++ b/building/configlet/lint.md
@@ -82,9 +82,6 @@ The `config.json` file should have the following checks:
 - The `"exercises.concept[].name"` value must be a Title Case string³ with length <= 255
 - The `"exercises.concept[].uuid"` key is required
 - The `"exercises.concept[].uuid"` value must be a unique, lowercased v4 UUID string
-- The `"exercises.concept[].deprecated"` key is optional
-- The `"exercises.concept[].deprecated"` value must be a boolean value
-- The `"exercises.concept[].deprecated"` value must generate a warning if set to `false`
 - The `"exercises.concept[].concepts"` key is required
 - The `"exercises.concept[].concepts"` value must be a non-empty array of strings if `"exercises.concept[].status"` is not equal to `deprecated`
 - The `"exercises.concept[].concepts"` value must be an empty array if `"exercises.concept[].status"` is equal to `deprecated`
@@ -113,9 +110,6 @@ The `config.json` file should have the following checks:
 - The `"exercises.practice[].name"` value must be a Title Case string³ with length <= 255
 - The `"exercises.practice[].uuid"` key is required
 - The `"exercises.practice[].uuid"` value must be a unique, lowercased v4 UUID string
-- The `"exercises.practice[].deprecated"` key is optional
-- The `"exercises.practice[].deprecated"` value must be a boolean value
-- The `"exercises.practice[].deprecated"` value must generate a warning if set to `false`
 - The `"exercises.practice[].difficulty"` key is required
 - The `"exercises.practice[].difficulty"` value must be an integer >= 0 and <= 10
 - The `"exercises.practice[].practices"` key is required


### PR DESCRIPTION
This PR makes the `configlet lint` spec match these docs:
- [building/tracks/config-json.md](https://github.com/exercism/docs/blob/214c88b7e85e/building/tracks/config-json.md)
- [building/tracks/deprecated-exercises.md](https://github.com/exercism/docs/blob/214c88b7e85e/building/tracks/deprecated-exercises.md)

The property named `deprecated` was replaced by the `status` key having
a value of "deprecated", and no track still uses the property named
`deprecated`.


---

As far as I can tell looking through every track-level `config.json` locally, no track still uses this property. Could a reviewer confirm this? Also, these only show results in the old `exercism/v3` repo:
- https://github.com/search?q=org%3Aexercism+%22deprecated%3A+false%22&type=code
- https://github.com/search?q=org%3Aexercism+%22deprecated%3A+true%22&type=code

The [building/tracks/config-json.md](https://github.com/exercism/docs/blob/214c88b7e85ed924fa6ac637f7d5bbd5fbd0c721/building/tracks/config-json.md) file doesn't mention this property:

> ### Concept exercises
> 
> Each concept exercise is an entry in the `exercises.concept` array.
> Exercises are ordered on the website in the same order they are listed in this file, and should match the typical order in which they should be solved.
> The following fields make up a concept exercise:
> 
> - `uuid`: a V4 UUID that uniquely identifies the exercise. The UUID must be unique both within the track as well as across all tracks
> - `slug`: the exercise's slug, which is a lowercased, kebab-case string. The slug must be unique across all concept _and_ practice exercise slugs within the track. Its length must be <= 255. 
> - `name`: the exercise's name. Its length must be <= 255. 
> - `concepts`: an array of concept slugs that are taught by this concept exercise
> - `prerequisites`: an array of concept slugs that must be unlocked before a student can start this exercise
> - `status` (optional): the exercise's status, which is one of `"wip"`, `"beta"` `"active"`, or `"deprecated"`; defaults to `"active"` if not specified
>   - `wip`: A work-in-progress exercise not ready for public consumption. Exercises with this tag will not be shown to students on the UI or be used for unlocking logic. They may appear for maintainers.
>   - `beta`: This signifies active exercises that are new and which we would like feedback on. We show a beta label on the site for these exercise, with a Call To Action of "Please give us feedback."
>   - `active`: The normal state of active exercises
>   - `deprecated`: Exercises that are no longer shown to students who have not started them (not usable at this stage). See [Deprecated Exercises](./deprecated-exercises) for more information.


> ### Practice exercises
> 
> Each concept exercise is an entry in the `exercises.practice` array. The following fields make up a concept exercise:
> 
> - `uuid`: a V4 UUID that uniquely identifies the exercise. The UUID must be unique both within the track as well as across all tracks
> - `slug`: the exercise's slug, which is a lowercased, kebab-case string. The slug must be unique across all concept _and_ practice exercise slugs within the track. Its length must be <= 255. 
> - `name`: the exercise's name. Its length must be <= 255. 
> - `practices`: an array of concept slugs that the exercise is helping students practice
> - `prerequisites`: an array of concept slugs that must be unlocked before a student can start the exercise
> - `difficulty`: a number indicating the difficulty of the exercise. The number must be in the range of 0 (easiest) to 10 (hardest)
> - `status` (optional): the exercise's status, which is either `"wip"`, `"beta"`, `"active"` or `"deprecated"`; defaults to `"active"` if not specified
>   - `wip`: A work-in-progress exercise not ready for public consumption. Exercises with this tag will not be shown to students on the UI or be used for unlocking logic. They may appear for maintainers.
>   - `beta`: This signifies active exercises that are new and which we would like feedback on. We show a beta label on the site for these exercise, with a Call To Action of "Please give us feedback"
>   - `active`: The normal state of active exercises
>   - `deprecated`: Exercises that are no longer shown to students who have not started them (not usable at this stage).


And searching this repo for "deprecated" with this PR:
```
$ git grep --break --heading 'deprecated'
building/config.json
489:    "slug": "tracks/deprecated-exercises",
490:    "path": "building/tracks/deprecated-exercises.md",

building/configlet/lint.md
86:- The `"exercises.concept[].concepts"` value must be a non-empty array of strings if `"exercises.concept[].status"` is not equal to `deprecated`
87:- The `"exercises.concept[].concepts"` value must be an empty array if `"exercises.concept[].status"` is equal to `deprecated`
93:- The `"exercises.concept[].prerequisites"` value must be a non-empty array of strings if `"exercises.concept[].status"` is not equal to `deprecated`, except for exactly one exercise which _is_ allowed to have an empty array as its value
94:- The `"exercises.concept[].prerequisites"` value must be an empty array if `"exercises.concept[].status"` is equal to `deprecated`
102:- The `"exercises.concept[].status"` value must be the string `wip`, `beta`, `active` or `deprecated`
116:- The `"exercises.practice[].practices"` value must be a non-empty array of strings if `"exercises.practice[].status"` is not equal to `deprecated`
117:- The `"exercises.practice[].practices"` value must be an empty array if `"exercises.practice[].status"` is equal to `deprecated`
123:- The `"exercises.practice[].prerequisites"` value must be a non-empty array of strings if `"exercises.practice[].status"` is not equal to `deprecated`
124:- The `"exercises.practice[].prerequisites"` value must be an empty array if `"exercises.practice[].status"` is equal to `deprecated`
131:- The `"exercises.practice[].status"` value must be the string `wip`, `beta`, `active` or `deprecated`

building/tracks/config-json.md
96:- `status` (optional): the exercise's status, which is one of `"wip"`, `"beta"` `"active"`, or `"deprecated"`; defaults to `"active"` if not specified
100:  - `deprecated`: Exercises that are no longer shown to students who have not started them (not usable at this stage). See [Deprecated Exercises](./deprecated-exercises) for more information.
151:- `status` (optional): the exercise's status, which is either `"wip"`, `"beta"`, `"active"` or `"deprecated"`; defaults to `"active"` if not specified
155:  - `deprecated`: Exercises that are no longer shown to students who have not started them (not usable at this stage).

building/tracks/deprecated-exercises.md
5:Instead, we allow exercises to be deprecated.
12:To help with this, we have config rules that accompany a deprecated exercise
17:- **`status`** set to `deprecated`
25:All other fields in deprecated exercises can be safely changed or removed in accordance with the wider config rules.

dev/badges.md
122:- Where did it go?: completed an exercise that has since been deprecated
```