### PR TITLE
State that an icon can be used regardless of its name

### DIFF
--- a/building/tracks/config-json.md
+++ b/building/tracks/config-json.md
@@ -248,7 +248,7 @@ The key features are specified in the top-level `key_features` field which is de
 
 - `title`: a concise header for the key feature. Its length must be <= 25. Markdown is _not_ supported.
 - `content`: a description of the key feature. Its length must be <= 100. Markdown is _not_ supported.
-- `icon`: the icon to show for the feature. The following icons can be used:
+- `icon`: the icon to show for the feature. You can choose an icon that you think fits, regardless of its name. The following icons can be used:
   - `community`
   - `concurrency`
   - `cross-platform`


### PR DESCRIPTION
If this is what we want, let's document it.

For example, let's say that a track has the key feature of "Simple", but the track maintainer thinks that the icon for `multi-paradigm` fits better than that for `easy`. 

![`multi-paradigm`](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/multi-paradigm.svg) `multi-paradigm`

![`easy`](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/easy.svg) `easy`

Another example: for a key feature of "Safe", a track might prefer the icon for `immutable` than that for `safe`:

![`immutable`](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/immutable.svg) `immutable`

![`safe`](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/safe.svg) `safe`

With this PR, we document this as allowed.

The problem I see: if the icon changes in the future, the icon might no longer match the feature on a track that was relying on the image rather than the filename. So we might want to have a rule that icons aren't changed much (or if they are, that we check their current uses).