### PR TITLE
State that each UUID should be immutable

### DIFF
--- a/building/configlet/lint.md
+++ b/building/configlet/lint.md
@@ -113,6 +113,7 @@ The `config.json` file should have the following checks:
 - The `"exercises.concept[].name"` value must be a Title Case string³ with length <= 255
 - The `"exercises.concept[].uuid"` key is required
 - The `"exercises.concept[].uuid"` value must be a unique version 4 UUID string⁵
+- The `"exercises.concept[].uuid"` value for each exercise must never change
 - The `"exercises.concept[].concepts"` key is required
 - The `"exercises.concept[].concepts"` value must be a non-empty array of strings if `"exercises.concept[].status"` is not equal to `deprecated`
 - The `"exercises.concept[].concepts"` value must be an empty array if `"exercises.concept[].status"` is equal to `deprecated`
@@ -141,6 +142,7 @@ The `config.json` file should have the following checks:
 - The `"exercises.practice[].name"` value must be a Title Case string³ with length <= 255
 - The `"exercises.practice[].uuid"` key is required
 - The `"exercises.practice[].uuid"` value must be a unique version 4 UUID string⁵
+- The `"exercises.practice[].uuid"` value for each exercise must never change
 - The `"exercises.practice[].difficulty"` key is required
 - The `"exercises.practice[].difficulty"` value must be an integer >= 0 and <= 10
 - The `"exercises.practice[].practices"` key is required
@@ -171,6 +173,7 @@ The `config.json` file should have the following checks:
 - The `"concepts"` value must have a entry with a matching `"slug"` property for each concept listed in a concept exercise's `"concepts"` property
 - The `"concepts[].uuid"` key is required
 - The `"concepts[].uuid"` value must be a unique version 4 UUID string⁵
+- The `"concepts[].uuid"` value for each concept must never change
 - The `"concepts[].slug"` key is required
 - The `"concepts[].slug"` value must be a kebab-case string² with length <= 255
 - The `"concepts[].name"` key is required

--- a/building/tracks/config-json.md
+++ b/building/tracks/config-json.md
@@ -88,7 +88,7 @@ Each concept exercise is an entry in the `exercises.concept` array.
 Exercises are ordered on the website in the same order they are listed in this file, and should match the typical order in which they should be solved.
 The following fields make up a concept exercise:
 
-- `uuid`: a V4 UUID that uniquely identifies the exercise. The UUID must be unique both within the track as well as across all tracks
+- `uuid`: a V4 UUID that uniquely identifies the exercise. The UUID must be unique both within the track as well as across all tracks, and must never change
 - `slug`: the exercise's slug, which is a lowercased, kebab-case string. The slug must be unique across all concept _and_ practice exercise slugs within the track. Its length must be <= 255.
 - `name`: the exercise's name. Its length must be <= 255.
 - `concepts`: an array of concept slugs that are taught by this concept exercise
@@ -142,7 +142,7 @@ The following fields make up a concept exercise:
 
 Each concept exercise is an entry in the `exercises.practice` array. The following fields make up a concept exercise:
 
-- `uuid`: a V4 UUID that uniquely identifies the exercise. The UUID must be unique both within the track as well as across all tracks
+- `uuid`: a V4 UUID that uniquely identifies the exercise. The UUID must be unique both within the track as well as across all tracks, and must never change
 - `slug`: the exercise's slug, which is a lowercased, kebab-case string. The slug must be unique across all concept _and_ practice exercise slugs within the track. Its length must be <= 255.
 - `name`: the exercise's name. Its length must be <= 255.
 - `practices`: an array of concept slugs that the exercise is helping students practice
@@ -220,7 +220,7 @@ Reasons for why an track might _not_ want to implement an exercise could be:
 
 Each concept is an entry in the top-level `concepts` array. The following fields make up a concept:
 
-- `uuid`: a V4 UUID that uniquely identifies the concept. The UUID must be unique both within the track as well as across all tracks
+- `uuid`: a V4 UUID that uniquely identifies the concept. The UUID must be unique both within the track as well as across all tracks, and must never change
 - `slug`: the concept's slug, which is a lowercased, kebab-case string. The slug must be unique across all concepts within the track. Its length must be <= 255.
 - `name`: the concept's name. Its length must be <= 255.
 


### PR DESCRIPTION
In the future, I think `configlet lint` should produce an error for a PR that changes an existing UUID.

Feel free to nit-pick the wording. Maybe "must" -> "should", given that it is possible for a duplicate UUID to be merged, which means we have to change it (`configlet lint` will pass if two PRs are created at the same time on different tracks, adding the same UUID).

---

Is a UUID change rejected at sync-time? 

From these it seems like the answer is "no"
- https://exercism-team.slack.com/archives/CARRG4MNC/p1626926137356200
- https://exercism.io/tracks/vbnet/exercises (two `two-fer` exercises)

---

Can we think of similar checks to add? For example: is there anything that we reject at sync-time that doesn't appear as a requirement in `lint.md`?

Perhaps:
- An exercise being removed
- An exercise being renamed (is this allowed?)
- A concept being renamed (is this allowed?)