### PR TITLE
Fix links to files in the contributing dir.

### DIFF
--- a/building/tracks/README.md
+++ b/building/tracks/README.md
@@ -35,7 +35,7 @@ Some parts of the track can be displayed in [widgets](./widgets.md), such as [co
 
 ## Style guide
 
-All documents should adhere to the [style guide](../../contributing/standards/style-guide.md). Markdown documents should also adhere to our [Markdown standards](../../contributing/standards/markdown.md).
+All documents should adhere to the [style guide](../../building/markdown/style-guide.md). Markdown documents should also adhere to our [Markdown standards](../../building/markdown/markdown.md).
 
 ## Example
 

--- a/community/contributors.md
+++ b/community/contributors.md
@@ -16,4 +16,4 @@ There are lots of different ways to help with Exercism:
 
 ...and much more.
 
-Visit our dedicated [Contributing Section](/contributing) to explore all the tasks that currently need doing.
+Visit our dedicated [Contributing Section](/building) to explore all the tasks that currently need doing.


### PR DESCRIPTION
`contributing` directory seems to have moved to `building`.  This PR fixes broken links in this repo.