### PR TITLE
Add gitter link

### DIFF
--- a/using/README.md
+++ b/using/README.md
@@ -3,6 +3,9 @@
 These documents describe how to make the most of your experience on Exercism.
 
 - [Getting Started](/docs/using/getting-started)
-- [Getting Feedback](/docs/using/feedback)
+- [Frequently Asked Questions](/docs/using/faqs)
 - [Solving Exercises](/docs/using/solving-exercises)
+- [Getting Feedback](/docs/using/feedback)
 - [Product](/docs/using/product)
+- [Contact](/docs/using/contact)
+- [Report Abuse](/docs/using/report-abuse)

--- a/using/contact.md
+++ b/using/contact.md
@@ -1,6 +1,8 @@
 # Contact Us
 
-The best place to get help with Exercism is on Github at [https://github.com/exercism/exercism](https://github.com/exercism/exercism). You are welcome to open issues for support requests, ask questions, suggest features, or anything else there.
+The best place to get help with Exercism is in the [online support chat](https://gitter.im/exercism/support).
+
+The second best place to get help with Exercism is on Github at [https://github.com/exercism/exercism](https://github.com/exercism/exercism). You are welcome to open issues for support requests, ask questions, suggest features, or anything else there.
 
 If you'd like to get in touch privately please email us at [hello@exercism.io](mailto:hello@exercism.io), but please note that due to the quantity of emails we get we may not reply if the question would be more appropriate on GitHub.
 


### PR DESCRIPTION
I'd like to point people to the gitter channel for help first instead of the github repo.