### PR TITLE
Conditionally require message field

### DIFF
--- a/building/tooling/test-runners/interface.md
+++ b/building/tooling/test-runners/interface.md
@@ -123,7 +123,7 @@ The following per-test statuses are valid:
 
 #### Message
 
-> key: `message`, type: `string`, presence: optional
+> key: `message`, type: `string`, presence: required if `status` is `fail` or `error`
 
 > version: 2, 3
 


### PR DESCRIPTION
I think test runner's `message` field of a test case is required when its status is `fail` or `error`.