### PR TITLE
Added image for mentoring queue

### DIFF
--- a/mentoring/choosing_a_solution.md
+++ b/mentoring/choosing_a_solution.md
@@ -9,7 +9,8 @@ The first decision you need to make as a mentor is which solution to mentor.
 You can find a list of all solutions that have been submitted for mentoring in the [Mentoring Queue](/mentoring/queue).
 The UI should look something like this:
 
-[TODO: Image of queue].
+![Mentoring queue](https://user-images.githubusercontent.com/48586518/132089298-deecce28-c62d-4bf6-91db-4cf92cc6f2c5.png "Mentoring queue")
+
 
 If you have a particular student you'd like to mentor, you can search using the filter box, and you can order by oldest or most recent.
 On the right-hand side you can filter by language or exercise.


### PR DESCRIPTION
I was looking at the '[Choosing a solution to mentor](https://exercism.org/docs/mentoring/choosing-a-solution)' page and I saw that there was no image of the mentoring queue. So I added the following image:
![mentoring queue](https://user-images.githubusercontent.com/48586518/132089491-f4c35961-be65-4866-a276-d9b62c948b48.png)
Hope this helps!