### PR TITLE
Remove merge conflict symbols from using/README.md

### DIFF
--- a/using/README.md
+++ b/using/README.md
@@ -7,9 +7,6 @@ These documents describe how to make the most of your experience on Exercism.
 - [Solving Exercises](/docs/using/solving-exercises)
 - [Getting Feedback](/docs/using/feedback)
 - [Product](/docs/using/product)
-<<<<<<< HEAD
-=======
 - [FAQs](/docs/using/faqs)
->>>>>>> Add other using links to README
 - [Contact](/docs/using/contact)
 - [Report Abuse](/docs/using/report-abuse)


### PR DESCRIPTION
There were git merge conflict symbols in docs/using/README.md and they are visible at https://exercism.org/docs/using.