### PR TITLE
Fix links in README to point to the correct path

### DIFF
--- a/mentoring/README.md
+++ b/mentoring/README.md
@@ -2,5 +2,5 @@
 
 Welcome to the Exercism Mentoring Team. Follow the links below for guides on how to get started with mentoring on Exercism!
 
-- [Choosing a Solution](/docs/mentoring/choosing-a-solution)
-- [How to give great feedback](/docs/mentoring/how-to-give-great-feedback)
+- [Choosing a Solution](/mentoring/choosing_a_solution.md)
+- [How to give great feedback](/mentoring/how_to_give_great_feedback.md)


### PR DESCRIPTION
The links in mentoring/README.md were pointing to the wrong file paths. I updated them to match the file names:

`/mentoring/choosing_a_solution.md`
and
`/mentoring/how_to_give_great_feedback.md`
#172 