### PR TITLE
Remove duplicate linting rule

### DIFF
--- a/building/configlet/lint.md
+++ b/building/configlet/lint.md
@@ -170,7 +170,6 @@ The `config.json` file should have the following checks:
 - The `"exercises.foregone"` values must not match any of the concept or practice exercise slugs
 - The `"concepts"` key is required
 - The `"concepts"` value must be an array
-- The `"concepts"` value must have a entry with a matching `"slug"` property for each concept listed in a concept exercise's `"concepts"` property
 - The `"concepts[].uuid"` key is required
 - The `"concepts[].uuid"` value must be a unique version 4 UUID string⁵
 - The `"concepts[].uuid"` value for each concept must never change


### PR DESCRIPTION
This was a duplicate of a previous rule:

> - The `"exercises.concept[].concepts"` values must match the `"concepts.slug"` property of one of the concepts

---

Pinging @ErikSchierboom for review: This was a duplicate, right?

Is the intention that we also check the other way around? That is, should `configlet lint` complain if a `concepts.slug`value does not exist in any `exercises.concept[].concepts` array?