### PR TITLE
Fix broken reputation link

### DIFF
--- a/using/getting-started.md
+++ b/using/getting-started.md
@@ -32,7 +32,7 @@ Want to help share your knowledge with others?
 Then [mentoring](/mentoring) is perfect for you!
 
 Mentoring is a fun and rewarding way to reinforce your own learning, while helping others learn and discover things they don't know.
-Mentoring also earns [reputation](/docs/building/product/reputation).
+Mentoring also earns [reputation](/docs/using/product/reputation).
 
 Not sure if you can mentor effectively?
 Some of our best mentors worried too.
@@ -54,4 +54,4 @@ We'll help you submit your first pull request.
 
 Got a contribution merged? Great!
 You'll be listed as a contributor on the website.
-Each contribution also earns [reputation](/docs/building/product/reputation).
+Each contribution also earns [reputation](/docs/using/product/reputation).


### PR DESCRIPTION
'reputation' links pointed to /docs/building/product/reputation which gives a 404 error, correct link should be /docs/using/product/reputation