### PR TITLE
MarkdownGuide Typos and Organization

### DIFF
--- a/building/markdown/markdown.md
+++ b/building/markdown/markdown.md
@@ -149,11 +149,11 @@ You can test that your markdown comment gets removed by checking how your commen
 
 There are various rules you can use to configure linters to meet this spec:
 
-- Enable [MD001][MD001]
-- Enable [MD002][MD002]
-- Use `atx` for [MD003][MD0003]
-- Disable [MD013][MD013]
-- Disable [MD033][MD033]
+- [MD001][MD001]: Enable
+- [MD002][MD002]: Enable
+- [MD003][MD003]: Use `atx` style
+- [MD013][MD013]: Disable
+- [MD033][MD033]: Disable
 
 ## Auto formatting
 
@@ -168,12 +168,13 @@ All the above can greatly help reduce churn in reviews, which is frustrating for
 
 ---
 
-[asciidoctor]: https://asciidoctor.org/docs/asciidoc-recommended-practices/#one-sentence-per-line
-[reference-links]: https://spec.commonmark.org/0.29/#reference-link
-[language-identifier]: https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
 [MD001]: https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md002---header-levels-should-only-increment-by-one-level-at-a-time
 [MD002]: https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md002---first-header-should-be-a-top-level-header
-[MD0003]: https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md003---header-style
+[MD003]: https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md003---header-style
 [MD013]: https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md013---line-length
 [MD033]: https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md033---inline-html
+[asciidoctor]: https://asciidoctor.org/docs/asciidoc-recommended-practices/#one-sentence-per-line
+[google-link]: https://google.com
+[language-identifier]: https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
 [prettier]: https://prettier.io/
+[reference-links]: https://spec.commonmark.org/0.29/#reference-link

--- a/building/markdown/markdown.md
+++ b/building/markdown/markdown.md
@@ -46,7 +46,7 @@ If you want some more information, [Google][google-link] is a useful resource.
 [google-link]: https://google.com
 ```
 
-Which renders as, "If you want some more information, [Google](https://google.com)".
+Which renders as, "If you want some more information, [Google][google-link]".
 
 ## Code
 

--- a/building/markdown/markdown.md
+++ b/building/markdown/markdown.md
@@ -18,7 +18,7 @@ All rules are being added to our CI and linting tools, and should be adhered to 
 
 Please use [reference links][reference-links], which are defined at the bottom of the Markdown file, mapped to a reference slug, and referenced by that slug in the text.
 
-This method makes maintenance easier, since link only have to be updated in a single location.
+This method makes maintenance easier, since link(s) only have to be updated in a single location.
 
 Example:
 

--- a/building/markdown/markdown.md
+++ b/building/markdown/markdown.md
@@ -138,7 +138,7 @@ Exercism is a very intentional product - things are there because they've been d
 
 - Prefer Markdown comments instead of HTML comments (e.g. use `[comment]: # (Actual comment...)` rather than `<!-- Actual comment -->`
 
-You can test that your markdown comment gets removed by checking how your comment looks when rendered via commonmark at [babelmark2](https://johnmacfarlane.net/babelmark2/?text=above%0A%0A%5Bcomment%5D%3A+%23+)(THIS+SHOULD+BE+REMOVED)%0Abelow
+You can test that your markdown comment gets removed by checking how your comment looks when rendered via commonmark at [babelmark2][balbelmark2].
 
 ## Inline HTML
 
@@ -174,6 +174,7 @@ All the above can greatly help reduce churn in reviews, which is frustrating for
 [MD013]: https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md013---line-length
 [MD033]: https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md033---inline-html
 [asciidoctor]: https://asciidoctor.org/docs/asciidoc-recommended-practices/#one-sentence-per-line
+[balbelmark2]: https://johnmacfarlane.net/babelmark2/?text=above%0A%0A%5Bcomment%5D%3A+%23+\(THIS+SHOULD+BE+REMOVED\)%0Abelow
 [google-link]: https://google.com
 [language-identifier]: https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
 [prettier]: https://prettier.io/


### PR DESCRIPTION
Found the idea of organizing a single link to not show the real value,
and continued to find things that I might improve for the documentation;

- Plural potential when it comes to link(s)
- Render link from actual desired use
- Sort the things, with alignment.

