### PR TITLE
Add examples for size labels

### DIFF
--- a/using/product/reputation.md
+++ b/using/product/reputation.md
@@ -61,23 +61,25 @@ For each concept where the user is listed as a contributor, `5` reputation is aw
 
 ### Creating a pull request
 
-For each merged pull request that was opened by the user, `12` reputation is awarded.
+By default, `12` reputation is awarded when a pull request is merged that was opened by the user.
 
+Depending on the content of the pull request, a maintainer can award more (or less) reputation by adding one of the following labels to the pull request:
+
+| Label            | Reputation | Examples                                                                                                                                                                                                                                                                                                                                                            |
+| ---------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `x:size/tiny`    | 3          | <ul><li>Fixing a single typo or link</li><li>Removing a blank line or adding a line break</li><li>Changing/adding a single code comment</li></ul>                                                                                                                                                                                                                   |
+| `x:size/small`   | 5          | <ul><li>Fixing a single test case, task or example</li><li>Fixing multiple typos or links in a single file</li><li>Clarifying content by adding a few lines to a file</li></ul>                                                                                                                                                                                     |
+| `x:size/medium`  | 12         | <ul><li>Syncing an exercise with problem-specifications (incl. edits)</li><li>Adding one or more test cases from scratch</li><li>Improving multiple files in an exercise</li><li>Adding mentor notes for an exercise from scratch</li><li>Fixing a small bug in a test runner/analyzer/representer</li><li>Adding analyzer comments for a single exericse</li></ul> |
+| `x:size/large`   | 30         | <ul><li>Adding a new concept or practice exercise</li><li>Adding new concept documentation</li><li>Substantial re-writing of an existing concept or exercise</li><li>Adding new CI scripts or other automation</li></ul>                                                                                                                                            |
+| `x:size/massive` | 100        | <ul><li>Creating a test-runner, analyzer, representer or generator from scratch</li><li>Major refactors to those tools</li><li>Creating major documentation from scratch (e.g. contribution or testing guides)</li></ul>                                                                                                                                            |
+
+The examples above can serve as rough orientation when to apply which label but maintainers are free to use their own judgement.
+
+- If more than one label is specified, the label with the highest reputation value determines the awarded reputation.
 - If a pull request is still open, no reputation is awarded (yet).
 - If a pull request is closed _without_ merging, no reputation is awarded.
-- In exceptional circumstances (either tiny PRs changing a few lines, or large PRs that will have taken a greater than normal of effort) is possible to award more (or less) reputation for a merged pull request by adding one of the following labels to the pull request:
 
-  | Label            | Reputation | Example                                                                                                                                                                        clarifying language of                                                                                                                                                               |
-  | ---------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-  | `x:size/tiny`    | 3          | <ul><li>Fixing a single typo or link</li><li>Removing a blank line or adding a line break</li><li>Changing/adding a single code comment</li></ul>                                                                                                                                                                                                                   |
-  | `x:size/small`   | 5          | <ul><li>Fixing a single test case, task or example</li><li>Fixing multiple typos or links in a single file</li><li>Clarifying content by adding a few lines to a file</li></ul>                                                                                                                                                                                     |
-  | `x:size/medium`  | 12         | <ul><li>Syncing an exercise with problem-specifications (incl. edits)</li><li>Adding one or more test cases from scratch</li><li>Improving multiple files in an exercise</li><li>Adding mentor notes for an exercise from scratch</li><li>Fixing a small bug in a test runner/analyzer/representer</li><li>Adding analyzer comments for a single exericse</li></ul> |
-  | `x:size/large`   | 30         | <ul><li>Adding a new concept or practice exercise</li><li>Adding new concept documentation</li><li>Substantial re-writing of an existing concept or exercise</li><li>Adding new CI scripts or other automation</li></ul>                                                                                                                                            |
-  | `x:size/massive` | 100        | <ul><li>Creating a test-runner, analyzer, representer or generator from scratch</li><li>Major refactors to those tools</li><li>Creating major documentation from scratch (e.g. contribution or testing guides)</li></ul>                                                                                                                                            |
-
-  If more than one label is specified, the label with the highest reputation value determines the awarded reputation.
-
-  Note that an `x:size` label on an **issue** never affects the awarded reputation - even if a merged pull request lacks an `x:size` label, and closes an issue that has one.
+Note that an `x:size` label on an **issue** never affects the awarded reputation - even if a merged pull request lacks an `x:size` label, and closes an issue that has one.
 
 ### Reviewing a pull requests
 

--- a/using/product/reputation.md
+++ b/using/product/reputation.md
@@ -67,13 +67,13 @@ For each merged pull request that was opened by the user, `12` reputation is awa
 - If a pull request is closed _without_ merging, no reputation is awarded.
 - In exceptional circumstances (either tiny PRs changing a few lines, or large PRs that will have taken a greater than normal of effort) is possible to award more (or less) reputation for a merged pull request by adding one of the following labels to the pull request:
 
-  | Label            | Reputation | Example                                         |
-  | ---------------- | ---------- | ----------------------------------------------- |
-  | `x:size/tiny`    | 3          | Fixing a typo                                   |
-  | `x:size/small`   | 5          | Adding or fixing a test case                    |
-  | `x:size/medium`  | 12         | Syncing an exercise with problem-specifications |
-  | `x:size/large`   | 30         | Adding a new concept exercise                   |
-  | `x:size/massive` | 100        | Creating a test-runner from scratch             |
+  | Label            | Reputation | Example                                                                                                                                                                        clarifying language of                                                                                                                                                               |
+  | ---------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+  | `x:size/tiny`    | 3          | <ul><li>Fixing a single typo or link</li><li>Removing a blank line or adding a line break</li><li>Changing/adding a single code comment</li></ul>                                                                                                                                                                                                                   |
+  | `x:size/small`   | 5          | <ul><li>Fixing a single test case, task or example</li><li>Fixing multiple typos or links in a single file</li><li>Clarifying content by adding a few lines to a file</li></ul>                                                                                                                                                                                     |
+  | `x:size/medium`  | 12         | <ul><li>Syncing an exercise with problem-specifications (incl. edits)</li><li>Adding one or more test cases from scratch</li><li>Improving multiple files in an exercise</li><li>Adding mentor notes for an exercise from scratch</li><li>Fixing a small bug in a test runner/analyzer/representer</li><li>Adding analyzer comments for a single exericse</li></ul> |
+  | `x:size/large`   | 30         | <ul><li>Adding a new concept or practice exercise</li><li>Adding new concept documentation</li><li>Substantial re-writing of an existing concept or exercise</li><li>Adding new CI scripts or other automation</li></ul>                                                                                                                                            |
+  | `x:size/massive` | 100        | <ul><li>Creating a test-runner, analyzer, representer or generator from scratch</li><li>Major refactors to those tools</li><li>Creating major documentation from scratch (e.g. contribution or testing guides)</li></ul>                                                                                                                                            |
 
   If more than one label is specified, the label with the highest reputation value determines the awarded reputation.
 

--- a/using/product/reputation.md
+++ b/using/product/reputation.md
@@ -67,13 +67,13 @@ For each merged pull request that was opened by the user, `12` reputation is awa
 - If a pull request is closed _without_ merging, no reputation is awarded.
 - In exceptional circumstances (either tiny PRs changing a few lines, or large PRs that will have taken a greater than normal of effort) is possible to award more (or less) reputation for a merged pull request by adding one of the following labels to the pull request:
 
-  | Label            | Reputation |
-  | ---------------- | ---------- |
-  | `x:size/tiny`    | 3          |
-  | `x:size/small`   | 5          |
-  | `x:size/medium`  | 12         |
-  | `x:size/large`   | 30         |
-  | `x:size/massive` | 100        |
+  | Label            | Reputation | Example                                         |
+  | ---------------- | ---------- | ----------------------------------------------- |
+  | `x:size/tiny`    | 3          | Fixing a typo                                   |
+  | `x:size/small`   | 5          | Adding or fixing a test case                    |
+  | `x:size/medium`  | 12         | Syncing an exercise with problem-specifications |
+  | `x:size/large`   | 30         | Adding a new concept exercise                   |
+  | `x:size/massive` | 100        | Creating a test-runner from scratch             |
 
   If more than one label is specified, the label with the highest reputation value determines the awarded reputation.
 


### PR DESCRIPTION
I think it would be good to have examples for which size label to use for which contributions. I noticed that maintainers often give their own work a lower size label than what they would give other contributors. Maybe these examples help that people label themselves and others fairly.

Happy to discuss what examples to use in more detail if needed, I mainly wanted to put this PR out as a starting point.

### Open Questions
* Do we want more than one example for each category? (not super easy to do formatting wise, lists in Markdown is a bit of a pain so I kept it to one example for now)
* There is the following text right above the table, is that still correct now that we have the more fine grained labels? It sounds a bit like it was meant for the old version where there was only small/medium/large. I am fine with keeping it, just wanted to make sure it isn't an artifact of an older version of the table.
  > In exceptional circumstances (either tiny PRs changing a few lines, or large PRs that will have taken a greater than normal of effort) is possible to award more (or less) reputation for a merged pull request by adding one of the following labels to the pull request