### PR TITLE
Add links on how to learn about GitHub and PRs

### DIFF
--- a/building/README.md
+++ b/building/README.md
@@ -17,5 +17,5 @@ You can read more about how to make sure your contribution is welcome in the doc
 [github]: https://github.com
 [github-course]: https://lab.github.com/githubtraining/introduction-to-github
 [pr-tutorial]: https://www.digitalocean.com/community/tutorials/how-to-create-a-pull-request-on-github
-[anthonywritescode]: https://www.youtube.com/watch?v=ECA-7erEJdU
+[anthonywritescode]: https://www.youtube.com/watch?v=cysuuUtbC6E
 [great-pr]: https://exercism.org/docs/community/being-a-good-community-member/pull-requests

--- a/building/README.md
+++ b/building/README.md
@@ -7,9 +7,10 @@ To get an idea where you could help, have a look at our [task list][tasks].
 
 Contributions to the code base are made via [GitHub][github].
 In case you are not familiar with GitHub and the contribution workflow, here are some resources that might help you getting started:
-* [Introduction to GitHub - Interactive Course][github-course]
-* [How To Create a Pull Request on GitHub - Tutorial][pr-tutorial]
-* [How To Make a Simple GitHub PR - Video by anthonywritescode][anthonywritescode]
+
+- [Introduction to GitHub - Interactive Course][github-course]
+- [How To Create a Pull Request on GitHub - Tutorial][pr-tutorial]
+- [How To Make a Simple GitHub PR - Video by anthonywritescode][anthonywritescode]
 
 You can read more about how to make sure your contribution is welcome in the documentation for [How to make a great Pull Request][great-pr].
 

--- a/building/README.md
+++ b/building/README.md
@@ -2,3 +2,20 @@
 
 This section of the docs looks at how to contribute to Exercism.
 It contains information and specifications for all various areas of Exercism as well as guides to things like becoming a maintainer and choosing a story for an exercise.
+
+To get an idea where you could help, have a look at our [task list][tasks].
+
+Contributions to the code base are made via [GitHub][github].
+In case you are not familiar with GitHub and the contribution workflow, here are some resources that might help you getting started:
+* [Introduction to GitHub - Interactive Course][github-course]
+* [How To Create a Pull Request on GitHub - Tutorial][pr-tutorial]
+* [How To Make a Simple GitHub PR - Video by anthonywritescode][anthonywritescode]
+
+You can read more about how to make sure your contribution is welcome in the documentation for [How to make a great Pull Request][great-pr].
+
+[tasks]: https://exercism.org/contributing/tasks
+[github]: https://github.com
+[github-course]: https://lab.github.com/githubtraining/introduction-to-github
+[pr-tutorial]: https://www.digitalocean.com/community/tutorials/how-to-create-a-pull-request-on-github
+[anthonywritescode]: https://www.youtube.com/watch?v=ECA-7erEJdU
+[great-pr]: https://exercism.org/docs/community/being-a-good-community-member/pull-requests


### PR DESCRIPTION
Erik mentioned [on Slack](https://exercism-team.slack.com/archives/GC3K95MRR/p1637135254157400?thread_ts=1637088992.155600&cid=GC3K95MRR) it would be good to have links to resources about GitHub and creating PRs in the docs.

I made a suggestion here. I also included a link to the task list and a link to the new page about great PRs on Exercism to give a bit more of a complete picture.

I was a bit unsure about where to put this exactly and decided for this main page for now. If we have more content later we could make a separate "General" section maybe.