### PR TITLE
Docs: Fix link to key feature icons

### DIFF
--- a/building/tracks/config-json.md
+++ b/building/tracks/config-json.md
@@ -511,4 +511,4 @@ This is an example of what a valid `config.json` file can look like:
 }
 ```
 
-[key-feature-icons]: /docs/building/tracks/icons#h-key-feature-icons
+[key-feature-icons]: /docs/building/tracks/icons.md#key-feature-icons

--- a/building/tracks/icons.md
+++ b/building/tracks/icons.md
@@ -350,4 +350,4 @@ There are two types of icons relevant to tracks:
 | widely-used       | <img width="50" height="50" alt="widely-used" src="https://dg8krxphbh767.cloudfront.net/key-features/widely-used.svg">             |
 
 [exercise-icons]: /docs/building/tracks/icons#h-exercise-icons
-[key-feature-icons]: /docs/building/tracks/icons#h-key-feature-icons
+[key-feature-icons]: /docs/building/tracks/icons.md#key-feature-icons


### PR DESCRIPTION
I'm not sure if there is anywhere else that this should be changed.
In this repo, this is all I could find with `grep -inr key-feature-icons .` in the root of this repo
