### PR TITLE
Fix copy-pasta error

### DIFF
--- a/building/tracks/config-json.md
+++ b/building/tracks/config-json.md
@@ -140,7 +140,7 @@ The following fields make up a concept exercise:
 
 ### Practice exercises
 
-Each concept exercise is an entry in the `exercises.practice` array. The following fields make up a concept exercise:
+Each practice exercise is an entry in the `exercises.practice` array. The following fields make up a practice exercise:
 
 - `uuid`: a V4 UUID that uniquely identifies the exercise. The UUID must be unique both within the track as well as across all tracks, and must never change
 - `slug`: the exercise's slug, which is a lowercased, kebab-case string. The slug must be unique across all concept _and_ practice exercise slugs within the track. Its length must be <= 255.


### PR DESCRIPTION
The practice exercises descriptions describes concept exercises when it should, of course, describe practice exercises.
Now I'm not sure if the `"prerequisites"` array in a practice exercise should list concept exercises or other practice exercises.