### PR TITLE
#350: Fix `building/configlet` dir with correct relative links

### DIFF
--- a/building/configlet/README.md
+++ b/building/configlet/README.md
@@ -6,22 +6,22 @@
 
 The primary function of configlet is to do _linting_: checking if a track's (configuration) files are properly structured - both syntactically and semantically.
 Misconfigured tracks may not sync correctly, may look wrong on the website, or may present a suboptimal user experience, so configlet's guards play an important part in maintaining the integrity of Exercism.
-The full list of rules that are checked by the linter can be found [here](/docs/building/configlet/lint).
+The full list of rules that are checked by the linter can be found [here](/docs/building/configlet/lint.md).
 
 ## Generating documents
 
 The secondary function of configlet is to generate documents. There are two types of documents that configlet can generate:
 
-1. A Concept Exercise's [`introduction.md` file](/docs/building/configlet/generating-documents#document-concept-exercises-introductionmd-file).
-1. A Practice Exercise's [`instructions.md` file](/docs/building/configlet/generating-documents#document-practice-exercises-instructionsmd-file).
+1. A Concept Exercise's [`introduction.md` file](/docs/building/configlet/generating-documents.md#document-concept-exercises-introductionmd-file).
+1. A Practice Exercise's [`instructions.md` file](/docs/building/configlet/generating-documents.md#document-practice-exercises-instructionsmd-file).
 
-How these documents are generated can be found [here](/docs/building/configlet/generating-documents).
+How these documents are generated can be found [here](/docs/building/configlet/generating-documents.md).
 
 ## Syncing exercise data with the problem-specifications repo
 
 The tertiary function of configlet is to various data for practice exercises. 
 
-A [Practice Exercise](/docs/building/tracks/practice-exercises) on an Exercism track is often implemented from a specification in the [`exercism/problem-specifications`](https://github.com/exercism/problem-specifications) repo.
+A [Practice Exercise](/docs/building/tracks/practice-exercises.md) on an Exercism track is often implemented from a specification in the [`exercism/problem-specifications`](https://github.com/exercism/problem-specifications) repo.
 
 Exercism deliberately requires that every exercise has its own copy of certain files (like `.docs/instructions.md`), even when that exercise exists in `problem-specifications`.
 Therefore configlet has a `sync` command, which can check that such Practice Exercises on a track are in sync with that upstream source, and can update them when updates are available.
@@ -34,19 +34,19 @@ Note that in `configlet` releases `4.0.0-alpha.34` and earlier, the `sync` comma
 To keep track of which tests are implemented for a specific practice exercise, the exercise _must_ contain a `.meta/tests.toml` file.
 Tests in this file are identified by their UUID and each test has a boolean value that indicates if it is implemented by that exercise.
 
-You can find the details about how to sync the different parts of an exercise [here](/docs/building/configlet/sync).
+You can find the details about how to sync the different parts of an exercise [here](/docs/building/configlet/sync.md).
 
 ## Generating UUIDs
 
 Exercises, tracks and concepts are identified by a UUID.
 
-How to generate UUIDs can be found [here](/docs/building/configlet/uuid).
+How to generate UUIDs can be found [here](/docs/building/configlet/uuid.md).
 
 ## Formatting
 
 Configlet has a `fmt` command to help with consistent formatting of the JSON files in the track repo.
 The `fmt` command currently only operates on the exercise `.meta/config.json` files but it is likely to operate on all the track JSON files in the future.
-You can learn more about the format command [here](/docs/building/configlet/format).
+You can learn more about the format command [here](/docs/building/configlet/format.md).
 
 ## Installation
 

--- a/building/configlet/generating-documents.md
+++ b/building/configlet/generating-documents.md
@@ -1,6 +1,6 @@
 # Configlet generating documents
 
-The secondary use of [configlet](/docs/building/configlet) is generating documents.
+The secondary use of [configlet](https://github.com/exercism/docs/tree/main/building/configlet) is generating documents.
 
 ## Usage
 
@@ -22,11 +22,11 @@ These are the documents that configlet can generate.
 
 ### Document: Concept Exercise's introduction.md file
 
-Each [Concept Exercise](/docs/building/tracks/concept-exercises) has an [`introduction.md` file](/docs/building/tracks/concept-exercises#docsintroductionmd). Each exercise can have an optional [`introduction.md.tpl` file](/docs/building/tracks/concept-exercises#docsintroductionmdtploptional).
+Each [Concept Exercise](../tracks/concept-exercises.md) has an [`introduction.md` file](../tracks/concept-exercises.md#docsintroductionmd). Each exercise can have an optional [`introduction.md.tpl` file](../tracks/concept-exercises.md#docsintroductionmdtploptional).
 
 The template file should be treated like a regular Markdown file but with one addition: the ability to specify placeholders. The following placeholders are supported:
 
-- `%{concept:<slug>}`: refers to the concept's [`introduction.md` document](/docs/building/tracks/concepts#fileintroductionmd)
+- `%{concept:<slug>}`: refers to the concept's [`introduction.md` document](../tracks/concepts.md#fileintroductionmd)
 
 When configlet detects that a Concept Exercise has an `introduction.md.tpl` file, it will generate a `introduction.md` file from it. The generated introduction will have the same contents as the template, expect for the placeholders, which will be replaced with the contents of the documents they refer to.
 

--- a/building/configlet/lint.md
+++ b/building/configlet/lint.md
@@ -1,6 +1,6 @@
 # Linting
 
-The primary use of [configlet](/docs/building/configlet) is linting: checking if a track's configuration files are properly structured - both syntactically and semantically. Misconfigured tracks may not sync correctly, may look wrong on the website, or may present a suboptimal user experience, so configlet's guards play an important part in maintaining the integrity of Exercism.
+The primary use of [configlet](https://github.com/exercism/docs/tree/main/building/configlet) is linting: checking if a track's configuration files are properly structured - both syntactically and semantically. Misconfigured tracks may not sync correctly, may look wrong on the website, or may present a suboptimal user experience, so configlet's guards play an important part in maintaining the integrity of Exercism.
 
 ## Usage
 

--- a/building/configlet/uuid.md
+++ b/building/configlet/uuid.md
@@ -1,6 +1,6 @@
 # Generating UUIDs
 
-Exercises, tracks and concepts are identified by a UUID. [configlet](/docs/building/configlet) can generate new, valid UUIDs.
+Exercises, tracks and concepts are identified by a UUID. [configlet](https://github.com/exercism/docs/tree/main/building/configlet) can generate new, valid UUIDs.
 
 ## Usage
 


### PR DESCRIPTION
For easy tracking: #350.

This PR fixes broken relative links inside `docs/building/configlet/` directory.