### PR TITLE
configlet(lint): fix quote usage

### DIFF
--- a/building/configlet/lint.md
+++ b/building/configlet/lint.md
@@ -80,34 +80,34 @@ The `config.json` file should have the following checks:
 - The `"online_editor.highlightjs_language"` value must be a non-blank string¹
 - The `"files"` key is optional
 - The `"files"` value must be an object
-- The `"files.solution`" key is optional
-- The `"files.solution`" value must be an array
-- The `"files.solution`" values must be valid patterns⁵
-- The `"files.solution`" values must not have duplicates
-- The `"files.test`" key is optional
-- The `"files.test`" value must be an array
-- The `"files.test`" values must be valid patterns⁵
-- The `"files.test`" values must not have duplicates
-- The `"files.example`" key is optional
-- The `"files.example`" value must be an array
-- The `"files.example`" values must be valid patterns⁵
-- The `"files.example`" values must not have duplicates
-- The `"files.exemplar"`" key is optional
-- The `"files.exemplar"`" value must be an array
-- The `"files.exemplar"`" values must be valid patterns⁵
-- The `"files.exemplar"`" values must not have duplicates
-- The `"files.editor`" key is optional
-- The `"files.editor`" value must be an array
-- The `"files.editor`" values must be valid patterns⁵
-- The `"files.editor`" values must not have duplicates
-- The `"files.invalidator`" key is optional
-- The `"files.invalidator`" value must be an array
-- The `"files.invalidator`" values must be valid patterns⁵
-- The `"files.invalidator`" values must not have duplicates
+- The `"files.solution"` key is optional
+- The `"files.solution"` value must be an array
+- The `"files.solution"` values must be valid patterns⁵
+- The `"files.solution"` values must not have duplicates
+- The `"files.test"` key is optional
+- The `"files.test"` value must be an array
+- The `"files.test"` values must be valid patterns⁵
+- The `"files.test"` values must not have duplicates
+- The `"files.example"` key is optional
+- The `"files.example"` value must be an array
+- The `"files.example"` values must be valid patterns⁵
+- The `"files.example"` values must not have duplicates
+- The `"files.exemplar"` key is optional
+- The `"files.exemplar"` value must be an array
+- The `"files.exemplar"` values must be valid patterns⁵
+- The `"files.exemplar"` values must not have duplicates
+- The `"files.editor"` key is optional
+- The `"files.editor"` value must be an array
+- The `"files.editor"` values must be valid patterns⁵
+- The `"files.editor"` values must not have duplicates
+- The `"files.invalidator"` key is optional
+- The `"files.invalidator"` value must be an array
+- The `"files.invalidator"` values must be valid patterns⁵
+- The `"files.invalidator"` values must not have duplicates
 - Patterns can only be listed in either the `"files.solution"`, `"files.test"`, `"files.example"`, `"files.exemplar"`, `"files.editor"` or `"files.invalidator"` array (no overlap)
   - If the track is `d` or `plsql`, the `"files.solution"` and `"files.test"` files _can_ overlap
   - The `"files.example` and `"files.exemplar"` files _can_ overlap
-- The `"test_runner.average_run_time"` key is required if `status.test_runner` is equal to `true`
+- The `"test_runner.average_run_time"` key is required if `"status.test_runner"` is equal to `true`
 - The `"test_runner.average_run_time"` value must be a floating-point number > 0 with one decimal point of precision
 - The `"exercises"` key is required
 - The `"exercises.concept"` key is required
@@ -433,7 +433,7 @@ The `config.json` file should have the following checks:
    > - Lowercase the second part of Latin species names.
 4. Sentence Case string: a non-blank string that follows the below guidelines (see https://en.wikipedia.org/wiki/Letter_case#Sentence_case):
    > - Capitalize the first word of the sentence, as well as proper nouns and other words as required by a more specific rule.
-5. Valid `files` pattern: A non-blank string¹ that specifies a location of a file used in an exercise, relative to the exercise's directory. A pattern may use one of the following placeholders:
+5. Valid `"files"` pattern: A non-blank string¹ that specifies a location of a file used in an exercise, relative to the exercise's directory. A pattern may use one of the following placeholders:
    - `%{kebab_slug}`: the `kebab-case` exercise slug (e.g. `bit-manipulation`)
    - `%{snake_slug}`: the `snake_case` exercise slug (e.g. `bit_manipulation`)
    - `%{camel_slug}`: the `camelCase` exercise slug (e.g. `bitManipulation`)


### PR DESCRIPTION
Noticed in https://github.com/exercism/docs/commit/322d63ecdbf6

I haven't checked hard that they're all consistent now.

