### PR TITLE
Document when the `tests` property is required

### DIFF
--- a/building/tooling/test-runners/interface.md
+++ b/building/tooling/test-runners/interface.md
@@ -63,7 +63,7 @@ When the status is not `error`, either set the value to `null` or omit the key e
 
 #### Tests
 
-> key: `tests`, type: `array`, presence: required
+> key: `tests`, type: `array`, presence: required if `status` = `fail` or `status` = `pass`
 
 > version: 2, 3
 


### PR DESCRIPTION
For a lot of test runners (especially the compiled language ones), the `tests` field cannot be reliably retrieved if there is an error running the tests. When the status is `error`, we don't show the tests anyway, so the field can be empty or omitted. This PR updates the spec to indicate this.

Closes https://github.com/exercism/docs/issues/355
