### PR TITLE
Fix broken link to javascript exercise

### DIFF
--- a/building/tracks/stories/numbers.freelancer-rates.md
+++ b/building/tracks/stories/numbers.freelancer-rates.md
@@ -52,5 +52,5 @@ These are recommendations, not rules, for recurring terminology in the instructi
 [types-floating-point-number]: https://github.com/exercism/v3/blob/main/reference/types/floating_point_number.md
 [types-string]: https://github.com/exercism/v3/blob/main/reference/types/string.md
 [implementation-elixir]: https://github.com/exercism/elixir/blob/main/exercises/concept/freelancer-rates/.docs/instructions.md
-[implementation-javascript]: https://github.com/exercism/javascript/blob/main/exercises/concept/numbers/.docs/instructions.md
+[implementation-javascript]: https://github.com/exercism/javascript/blob/main/exercises/concept/freelancer-rates/.docs/instructions.md
 [implementation-swift]: https://github.com/exercism/swift/blob/main/exercises/concept/freelancer-rates/.docs/instructions.md


### PR DESCRIPTION
The Freelancer Rates story lists the Javascript exercise as the
reference implementation, but the link was returning a 404.

It looks like the Javascript exercise was renamed at some point.

This fixes the link to point to the right place.