### PR TITLE
maintainers-pull-request-guide: fix name of reviewers team

### DIFF
--- a/building/github/maintainers-pull-request-guide.md
+++ b/building/github/maintainers-pull-request-guide.md
@@ -69,7 +69,7 @@ This greatly helps reduce the change of things becoming argumentative.
 
 If you'd like to request help reviewing a pull request, we have to specific teams you can ping:
 
-- `@exercism/reviews`: for any general reviews
+- `@exercism/reviewers`: for any general reviews
 - `@exercism/github-actions`: for any questions regarding [GitHub actions][github-actions]
 
 [problem-specifications]: https://github.com/exercism/problem-specifications


### PR DESCRIPTION
The team name is `reviewers`, not `reviews`:
https://github.com/orgs/exercism/teams/reviewers

Checking the team names in the current `main`:

```console
$ git rev-parse --short HEAD
adccf2c
$ git grep --break --heading '@exercism/'
building/github/maintainers:pull-request-guide.md
72:- `@exercism/reviewers`: for any general reviews
73:- `@exercism/github-actions`: for any questions regarding [GitHub actions][github-actions]

building/tooling/docker.md
70:All changes to Dockerfiles require a PR review from the @exercism/ops team, in order to avoid the introduction of security exploits.

building/tracks/ci/workflow:templates.md
118:If you run into any issues or want someone to review your workflows, please ping the `@exercism/github-actions` team.

building/tracks/concept:exercises.md
165:We place high value on making Exercism's content safe for everyone and so often err on the side of caution in deciding whether stories are appropriate or not. While we are careful about what we merge, we appreciate that it's hard to be aware of what may be seen as problematic, so we'll always assume you're acting in good faith and do our best to catch any issues in review in a non-confrontational way. If you'd like to check a story with us, please mention @exercism/leadership and we'll look at it toget→

building/tracks/new/find:maintainers.md
10:You can request a maintainer to be added by opening an issue and tagging `@exercism/staff`.

building/tracks/practice:exercises.md
107:We place high value on making Exercism's content safe for everyone and so often err on the side of caution in deciding whether stories are appropriate or not. While we are careful about what we merge, we appreciate that it's hard to be aware of what may be seen as problematic, so we'll always assume you're acting in good faith and do our best to catch any issues in review in a non-confrontational way. If you'd like to check a story with us, please mention @exercism/leadership and we'll look at it toget→
149:We place high value on making Exercism's content safe for everyone and so often err on the side of caution in deciding whether stories are appropriate or not. While we are careful about what we merge, we appreciate that it's hard to be aware of what may be seen as problematic, so we'll always assume you're acting in good faith and do our best to catch any issues in review in a non-confrontational way. If you'd like to check a story with us, please mention @exercism/leadership and we'll look at it toget→

community/administrators.md
33:If you feel a conversation is becoming draining and unproductive, or could move that way, please feel free to tag @exercism/maintainers-admin in a post to ask for guidance or reach out to one of the admins on Slack.

community/good:member/pull-requests.md
41:If you've not had a response within 7 days, please tag `@exercism/reviewers` in a **new** comment on the PR, and that will alert a wider team to it.
```