### PR TITLE
Fix broken link in join-our-community

### DIFF
--- a/building/tracks/new/join-our-community.md
+++ b/building/tracks/new/join-our-community.md
@@ -3,4 +3,4 @@
 To help interact with other maintainers (and mentors), we have created a Slack workspace.
 This is a great place to plan your track and to get help from other maintainers.
 It is also the place where we'll regularly post updates on things we're working on.
-To get access to this workspace, please email [erik@exercism.org](mailto:erik@exercism.org?subject=Exercism Slack Access Request).
+To get access to this workspace, please email [erik@exercism.org](mailto:erik@exercism.org?subject=Exercism%20Slack%20Access%20Request).


### PR DESCRIPTION
The mailto link to request slack access had a subject parameter with unencoded spaces.

This properly URL-encodes the spaces.