### PR TITLE
Remove inconsistencies about getting help

### DIFF
--- a/building/tooling/analyzers/creating-from-scratch.md
+++ b/building/tooling/analyzers/creating-from-scratch.md
@@ -9,7 +9,7 @@ These are the steps to get going:
 3. Open an issue at [exercism/exercism][exercism-repo] introducing yourself and telling us which language you'd like to create a Analyzer for.
 4. Once an Analyzer repo has been created, use [the Analyzer interface document](/docs/building/tooling/analyzers/interface) to help guide your implementation.
 
-We have an incredibly friendly and supportive community who will be happy to help you as you work through this! If you get stuck, please start a new topic on [the Exercism forum][forum] or create new issues at [exercism/exercism][exercism-repo] as needed 🙂
+We have an incredibly friendly and supportive community who will be happy to help you as you work through this! If you get stuck, please start a new topic on [the Exercism forum][building-exercism] or create new issues at [exercism/exercism][exercism-repo] as needed 🙂
 
-[forum]: https://forum.exercism.org/c/exercism/building-exercism/125
+[building-exercism]: https://forum.exercism.org/c/exercism/building-exercism/125
 [exercism-repo]: https://github.com/exercism/exercism

--- a/building/tooling/representers/creating-from-scratch.md
+++ b/building/tooling/representers/creating-from-scratch.md
@@ -9,7 +9,7 @@ These are the steps to get going:
 3. Open an issue at [exercism/exercism][exercism-repo] introducing yourself and telling us which language you'd like to create a Representer for.
 4. Once a Representer repo has been created, use [the Representer interface document](/docs/building/tooling/representers/interface) to help guide your implementation.
 
-We have an incredibly friendly and supportive community who will be happy to help you as you work through this! If you get stuck, please start a new topic on [the Exercism forum][forum] or create new issues at [exercism/exercism][exercism-repo] as needed 🙂
+We have an incredibly friendly and supportive community who will be happy to help you as you work through this! If you get stuck, please start a new topic on [the Exercism forum][building-exercism] or create new issues at [exercism/exercism][exercism-repo] as needed 🙂
 
-[forum]: https://forum.exercism.org/c/exercism/building-exercism/125
+[building-exercism]: https://forum.exercism.org/c/exercism/building-exercism/125
 [exercism-repo]: https://github.com/exercism/exercism

--- a/building/tooling/test-runners/creating-from-scratch.md
+++ b/building/tooling/test-runners/creating-from-scratch.md
@@ -9,7 +9,7 @@ These are the steps to get going:
 3. Open an issue at [exercism/exercism][exercism-repo] introducing yourself and telling us which language you'd like to create a Test Runner for.
 4. Once a Test Runner repo has been created, use [the Test Runner interface document](/docs/building/tooling/test-runners/interface) to help guide your implementation. There is a [generic test runner repository template](https://github.com/exercism/generic-test-runner/) that you can use to kick-start development.
 
-We have an incredibly friendly and supportive community who will be happy to help you as you work through this! If you get stuck, please start a new topic on [the Exercism forum][forum] or create new issues at [exercism/exercism][exercism-repo] as needed 🙂
+We have an incredibly friendly and supportive community who will be happy to help you as you work through this! If you get stuck, please start a new topic on [the Exercism forum][building-exercism] or create new issues at [exercism/exercism][exercism-repo] as needed 🙂
 
-[forum]: https://forum.exercism.org/c/exercism/building-exercism/125
+[building-exercism]: https://forum.exercism.org/c/exercism/building-exercism/125
 [exercism-repo]: https://github.com/exercism/exercism

--- a/building/tracks/shared-files.md
+++ b/building/tracks/shared-files.md
@@ -60,7 +60,7 @@ To get help if you're having trouble, you can use one of the following resources
 
 - [Kotlin Documentation](https://kotlinlang.org/docs/reference/)
 - [Kotlin Forums](https://discuss.kotlinlang.org/)
-- [Kotlin Slack Channel](http://kotlinlang.slack.com/): [get invite here](http://slack.kotlinlang.org/)
+- [Kotlin Slack Channel](https://kotlinlang.slack.com/): [get invite here](https://slack.kotlinlang.org/)
 - [Stack Overflow](https://stackoverflow.com/questions/tagged/kotlin)
 - [Kotlin Subreddit](https://www.reddit.com/r/kotlin)
 ```

--- a/building/tracks/shared-files.md
+++ b/building/tracks/shared-files.md
@@ -62,7 +62,7 @@ To get help if you're having trouble, you can use one of the following resources
 - [Kotlin Forums](https://discuss.kotlinlang.org/)
 - [Kotlin Slack Channel](http://kotlinlang.slack.com/): [get invite here](http://slack.kotlinlang.org/)
 - [Stack Overflow](https://stackoverflow.com/questions/tagged/kotlin)
-- [Reddit Channel](https://www.reddit.com/r/kotlin)
+- [Kotlin Subreddit](https://www.reddit.com/r/kotlin)
 ```
 
 ## File: `representations.md`

--- a/building/tracks/shared-files.md
+++ b/building/tracks/shared-files.md
@@ -56,7 +56,13 @@ This document should **not** link to Exercism-wide (track-agnostic) help resourc
 ```markdown
 # Help
 
-If you're having trouble, feel free to ask help in the programming category of [the Exercism forum](https://forum.exercism.org/c/programming/5).
+To get help if you're having trouble, you can use one of the following resources:
+
+- [Kotlin Documentation](https://kotlinlang.org/docs/reference/)
+- [Kotlin Forums](https://discuss.kotlinlang.org/)
+- [Kotlin Slack Channel](http://kotlinlang.slack.com/): [get invite here](http://slack.kotlinlang.org/)
+- [Stack Overflow](https://stackoverflow.com/questions/tagged/kotlin)
+- [Reddit Channel](https://www.reddit.com/r/kotlin)
 ```
 
 ## File: `representations.md`


### PR DESCRIPTION
We references to the unofficial Exercism help channels on
Gitter with references to the new official Exercism forum.

In a couple of places this introduced inconsistencies.

The first is a sample `help.md` file, where instead of
linking to the Gitter channel we referenced a language-
specific sub-channel on the forum. However this was in
a document where we discourage links to Exercism-wide
resources, which will already be included in the docs
seen by the end-user.

The second is the name of a markdown link-reference.
We were linking to the Building Exercism sub-channel,
but called the link-reference 'forum'. Elsewhere,
'forum' links to the top-level forum, and we've called
the reference 'building-exercism' when linking to
this category.

This fixes these inconsistencies.

With thanks to @ee7 for suggesting the improvements in #395 