### PR TITLE
Fix links in test runner README

### DIFF
--- a/building/tooling/test-runners/README.md
+++ b/building/tooling/test-runners/README.md
@@ -20,6 +20,6 @@ If you would like to create a Test Runner for a language that currently does not
 
 You can use the following documents to learn more about building a test runner:
 
-- [creating a Test Runner from scratch](/docs/building/tooling/test-runners/creating-from-scratch)
-- [The Test Runner interface](/docs/building/tooling/test-runners/interface)
-- [How to build a Docker image with Docker for local testing and deployment](/docs/building/tooling/test-runners/docker)
+- [creating a Test Runner from scratch](/building/tooling/test-runners/creating-from-scratch)
+- [The Test Runner interface](/building/tooling/test-runners/interface)
+- [How to build a Docker image with Docker for local testing and deployment](/building/tooling/test-runners/docker)


### PR DESCRIPTION
Hi! I'm assuming these docs are read here on GitHub and these links broke with some directory structure change. :)