### PR TITLE
configlet: add linting rule for practice exercise icon

### DIFF
--- a/building/configlet/lint.md
+++ b/building/configlet/lint.md
@@ -327,6 +327,8 @@ The `config.json` file should have the following checks:
 - The `"test_runner"` value must be a boolean
 - The `"representer.version"` key is optional
 - The `"representer.version"` value must be an integer >= 1
+- The `"icon"` key is optional
+- The `"icon"` value must be a kebab-case string²
 
 ### Rule: exercises/{concept|practice}/&lt;slug&gt;/.approaches/config.json is valid
 


### PR DESCRIPTION
The icon rule was not present even though the field was described in the practice exercise spec: https://github.com/exercism/docs/blob/main/building/tracks/practice-exercises.md#file-metaconfigjson