### PR TITLE
Remove dead link from Analyzer docs

### DIFF
--- a/building/tooling/analyzers/interface.md
+++ b/building/tooling/analyzers/interface.md
@@ -100,8 +100,7 @@ Exercism is responsible for the display and communication of comments. The analy
 
 The goal of a language track on Exercism is to give people a way to achieve a
 high level of [fluency](/docs/using/product/fluency) at a low level of proficiency. We're aiming for fluency
-in the syntax, idioms, and the standard library of the language. You can read
-more about the [goal of exercism here](https://github.com/exercism/docs/blob/main/about/goal-of-exercism.md).
+in the syntax, idioms, and the standard library of the language.
 
 ## Definitions
 


### PR DESCRIPTION
Looks like the linked page has been removed.