### PR TITLE
Update average run time

### DIFF
--- a/building/configlet/lint.md
+++ b/building/configlet/lint.md
@@ -108,7 +108,7 @@ The `config.json` file should have the following checks:
   - If the track is `d` or `plsql`, the `"files.solution"` and `"files.test"` files _can_ overlap
   - The `"files.example` and `"files.exemplar"` files _can_ overlap
 - The `"test_runner.average_run_time"` key is required if `"status.test_runner"` is equal to `true`
-- The `"test_runner.average_run_time"` value must be a floating-point number > 0 with one decimal point of precision
+- The `"test_runner.average_run_time"` value must be positive integer > 0 or a floating-point number > 0.0 with one decimal point of precision
 - The `"approaches.snippet_extension"` key is required if the track has one or more approaches
 - The `"approaches.snippet_extension"` value must be a non-blank string¹
 - The `"exercises"` key is required

--- a/building/configlet/lint.md
+++ b/building/configlet/lint.md
@@ -108,7 +108,7 @@ The `config.json` file should have the following checks:
   - If the track is `d` or `plsql`, the `"files.solution"` and `"files.test"` files _can_ overlap
   - The `"files.example` and `"files.exemplar"` files _can_ overlap
 - The `"test_runner.average_run_time"` key is required if `"status.test_runner"` is equal to `true`
-- The `"test_runner.average_run_time"` value must be positive integer > 0 or a floating-point number > 0.0 with one decimal point of precision
+- The `"test_runner.average_run_time"` value must be an integer > 0
 - The `"approaches.snippet_extension"` key is required if the track has one or more approaches
 - The `"approaches.snippet_extension"` value must be a non-blank string¹
 - The `"exercises"` key is required


### PR DESCRIPTION
There are two reasons for this change:

1. Having the average run time as a float gives the impression of being exact, whereas the actual run time wildly varies due to a wide variety of reasons (e.g. how busy it is on the server). That fractional component will almost never actually conform the real situation.

2. `jq` is often used to work with track `config.json` config files (e.g. to add elements to it), and it will remove any trailing `.0` fractional part from a number, which caused `configlet lint` to fail. Those JQ scripts then have to work around this by manually adding `.0` to it.