### PR TITLE
Add concept map documentation

### DIFF
--- a/building/config.json
+++ b/building/config.json
@@ -521,6 +521,13 @@
     "blurb": ""
   },
   {
+    "uuid": "0807db01-ce0e-4ac4-817b-7fe0a2366d01",
+    "slug": "tracks/concept-map",
+    "path": "building/tracks/concept-map.md",
+    "title": "Concept Map",
+    "blurb": ""
+  },
+  {
     "uuid": "2a29f722-e70d-4679-81f8-bd6727fa9013",
     "slug": "tracks/config-json",
     "path": "building/tracks/config-json.md",

--- a/building/tracks/README.md
+++ b/building/tracks/README.md
@@ -11,6 +11,9 @@ The track's configuration and metadata are specified in the `config.json` file. 
 All concept and practices exercises of a track involve _concepts_. These concepts are separate entities by themselves. Check the [documentation](/docs/building/tracks/concepts) for more information.
 
 The concepts taught in the track's concept exercises form a _syllabus_.
+The _syllabus_ is shown to students as a _concept map_.
+Check the [_concept map_ documentation](/docs/building/tracks/concept-map) to learn about building out the concept map for a _syllabus_.
+
 For more information on how to design a syllabus, check the [syllabus documentation](/docs/building/tracks/syllabus).
 
 ## Exercises

--- a/building/tracks/concept-map.md
+++ b/building/tracks/concept-map.md
@@ -44,5 +44,5 @@ flowchart TD
     linkStyle 2 stroke-width:2px,fill:none,stroke:red;
 ```
 
-[github-concept-code]: https://github.com/exercism/website/blob/e47525f66b036662138e5e41055430fe7963a282/app/commands/track/determine_concept_map_layout.rb
+[github-concept-code]: https://github.com/exercism/website/blob/main/app/commands/track/determine_concept_map_layout.rb
 [wikipedia-graph]: https://en.wikipedia.org/wiki/Graph_(discrete_mathematics)

--- a/building/tracks/concept-map.md
+++ b/building/tracks/concept-map.md
@@ -6,7 +6,7 @@ The concept map is one of the main methods to illustrate the progression that a 
 
 - Provide a meaningful concept map of ideas from simple to complex ideas.
 - Provide a pathway towards fluency in a language.
-- Illustrate the progression through the course [track] contents.
+- Illustrate the progression through the course contents.
 
 ## Structure
 

--- a/building/tracks/concept-map.md
+++ b/building/tracks/concept-map.md
@@ -1,0 +1,48 @@
+# Concept Map
+
+The concept map is one of the main methods to illustrate the progression that a student takes through the concept exercises.
+
+## Design Goals
+
+- Provide a meaningful concept map of ideas from simple to complex ideas.
+- Provide a pathway towards fluency in a language.
+- Illustrate the progression through the course [track] contents.
+
+## Structure
+
+- Nodes
+  - Each concept is represented by a node on the concept map.
+  - Provide a quick reference with their style to indicate the degree of progression.
+    - Mastered: Concepts whose learning exercise and all associate practice exercise is complete.
+    - Complete: Concepts whose learning exercise is complete, but one or more practice exercise is not complete.
+    - Available: Concepts whose learning exercise has not been completed.
+    - Locked: Concepts whose learning exercise requires one or more pre-requisite exercise to be completed.
+- Paths
+  - Provide a relation of one concept to the next.
+  - Provide a relation indicating the building blocks of a concept back to the root.
+
+## Configuration
+
+The configuration of the concept map is determined by details of the `config.json` associated to a track.
+Specifically the specification of the concept exercises determines the shape and layout of the concept map.
+
+> You can view the code used to compute the concept map specification on GitHub: [Exercism/website: determine_concept_map_layout.rb][github-concept-code]
+
+A concept exercise specifies its prerequites and also the concept it teaches on completion.
+If we translate this to the terms of a [graph][wikipedia-graph]:
+- A concept represents a _vertex_ (also known as a _node_)
+- A concept exercise determines one or more _directed edges_ between two _vertices_ (_nodes_)
+
+It is important to note, not all edges that could be specified from the `config.json` appear in the result -- only the edges from the preceeding level are selected.
+
+```mermaid
+flowchart TD
+    Basics --> Integers
+    Integers --> Strings
+    Basics --Edge Removed--> Strings
+
+    linkStyle 2 stroke-width:2px,fill:none,stroke:red;
+```
+
+[github-concept-code]: https://github.com/exercism/website/blob/e47525f66b036662138e5e41055430fe7963a282/app/commands/track/determine_concept_map_layout.rb
+[wikipedia-graph]: https://en.wikipedia.org/wiki/Graph_(discrete_mathematics)

--- a/building/tracks/concept-map.md
+++ b/building/tracks/concept-map.md
@@ -23,7 +23,7 @@ The concept map is one of the main methods to illustrate the progression that a 
 
 ## Configuration
 
-The configuration of the concept map is determined by details of the `config.json` associated to a track.
+The configuration of the concept map is determined by details of the [`config.json`](/docs/building/tracks/config-json) associated to a track.
 Specifically the specification of the concept exercises determines the shape and layout of the concept map.
 
 > You can view the code used to compute the concept map specification on GitHub: [Exercism/website: determine_concept_map_layout.rb][github-concept-code]

--- a/building/tracks/concepts.md
+++ b/building/tracks/concepts.md
@@ -1,6 +1,8 @@
 # Concepts
 
-Concepts are the things that a programmer would need to understand to be fluent in a language. Concepts are taught by Concept Exercises and are used as prerequisites for Concept- _and_ Practice Exercises.
+Concepts are the things that a programmer would need to understand to be fluent in a language.
+Concepts are taught by Concept Exercises and are used as prerequisites for Concept- _and_ Practice Exercises.
+Concepts are placed on to a [_concept map_](/docs/building/tracks/concept-map) when displayed to the student.  
 
 ## Metadata
 


### PR DESCRIPTION
Recent comments on the forum bring to light that there is relatively sparse documentation on:
- the requirements that were determined for the concept map
- the method of computation determining the specification for the concept map
- details about the resulting graph