### PR TITLE
[UX]: Add submission review note for test procedures

### DIFF
--- a/using/solving-exercises/working-locally.md
+++ b/using/solving-exercises/working-locally.md
@@ -45,6 +45,11 @@ Depending on the track, there might be other files that the track tooling requir
 
 ## Submitting your Solution
 
+~~~~exercism/note
+**Before you submit:** Review how tests work for your chosen language to avoid common errors.
+You can find these by navigating to [Tracks](https://exercism.org/docs/tracks/), selecting your language, and clicking **Testing on the [language] track** in the sidebar.
+~~~~
+
 Once your solution passes all the tests, you can submit your solution using the following command:
 
 ```


### PR DESCRIPTION
Added a note in local setup guide docs to link test related docs for fast onboarding and error/mistake free submittion from local setup.

This was mentioned in [Exercism Forum](https://forum.exercism.org/t/bug-faulty-test-cases-in-two-fer/48379) and I took initiative to do the PR.

Received go ahead from @SleeplessByte.

> Let me know if this needs improvement.