### PR TITLE
Fix minor error in Markdown Specification docs

### DIFF
--- a/building/markdown/markdown.md
+++ b/building/markdown/markdown.md
@@ -46,7 +46,7 @@ If you want some more information, [Google][google-link] is a useful resource.
 [google-link]: https://google.com
 ```
 
-Which renders as, "If you want some more information, [Google][google-link]".
+Which renders as, "If you want some more information, [Google][google-link] is a useful resource."
 
 ## Code
 


### PR DESCRIPTION
Fixes a minor error in the Markdown Specification docs as [discussed in this forum thread](https://forum.exercism.org/t/minor-error-in-markdown-specification-docs/52207).